### PR TITLE
SEO: stabilize sitemap lastModified and fix schema

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,12 +1,66 @@
 import type { MetadataRoute } from 'next';
 import { getPapers, getArticles, getConcepts, getBooks, getLanguages, getAlternateLanguages, getStaticPageAlternates } from '@/lib/content';
+import fs from 'fs';
+import path from 'path';
 
 export const dynamic = 'force-static';
 
 const SITE_URL = 'https://fractalresonance.com';
 
+function safeDateMs(raw: unknown): number | null {
+  if (typeof raw !== 'string' || !raw.trim()) return null;
+  const ms = Date.parse(raw);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function maxMs(values: Array<number | null | undefined>): number | null {
+  let out: number | null = null;
+  for (const v of values) {
+    if (typeof v !== 'number' || !Number.isFinite(v)) continue;
+    out = out === null ? v : Math.max(out, v);
+  }
+  return out;
+}
+
+function safeFileMtimeMs(relPathFromRepoRoot: string): number | null {
+  try {
+    const full = path.join(process.cwd(), relPathFromRepoRoot);
+    const stat = fs.statSync(full);
+    return stat.mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function latestItemDateMs(lang: string, getter: (lang: string) => any[]): number | null {
+  const items = getter(lang);
+  return maxMs(items.map((i) => safeDateMs(i?.frontmatter?.date)));
+}
+
+function latestContentDateMs(languages: string[]): number | null {
+  const values: Array<number | null> = [];
+  for (const lang of languages) {
+    values.push(latestItemDateMs(lang, getPapers));
+    values.push(latestItemDateMs(lang, getArticles));
+    values.push(latestItemDateMs(lang, getConcepts));
+    values.push(latestItemDateMs(lang, getBooks));
+  }
+  return maxMs(values);
+}
+
+function itemDateMsById(getter: (lang: string) => any[], lang: string, id: string): number | null {
+  const items = getter(lang);
+  const found = items.find((i) => i?.frontmatter?.id === id);
+  return safeDateMs(found?.frontmatter?.date);
+}
+
 export default function sitemap(): MetadataRoute.Sitemap {
   const languages = getLanguages();
+  const globalLastModifiedMs =
+    latestContentDateMs(languages) ??
+    safeFileMtimeMs('content') ??
+    safeFileMtimeMs('README.md') ??
+    Date.now();
   const entries: MetadataRoute.Sitemap = [];
 
   // Homepage with language alternates
@@ -14,23 +68,35 @@ export default function sitemap(): MetadataRoute.Sitemap {
   for (const lang of languages) {
     homeAlternates[lang] = `${SITE_URL}/${lang}`;
   }
+  homeAlternates['x-default'] = `${SITE_URL}/en`;
   entries.push({
     url: SITE_URL,
-    lastModified: new Date(),
+    lastModified: new Date(globalLastModifiedMs),
     changeFrequency: 'weekly',
     priority: 1.0,
     alternates: { languages: homeAlternates },
   });
 
   // Static pages with language alternates
-  const staticPages = ['about', 'articles', 'papers', 'books', 'formulas', 'positioning', 'mu-levels', 'graph', 'contact', 'privacy', 'terms'];
+  const staticPages = ['about', 'articles', 'papers', 'books', 'concepts', 'formulas', 'positioning', 'mu-levels', 'graph', 'contact', 'privacy', 'terms'];
 
   for (const page of staticPages) {
     const alternates = getStaticPageAlternates(page);
     for (const lang of languages) {
+      const url = alternates[lang] || `${SITE_URL}/${lang}/${page}`;
+      const lastMs =
+        page === 'papers'
+          ? latestItemDateMs(lang, getPapers)
+          : page === 'articles'
+            ? latestItemDateMs(lang, getArticles)
+            : page === 'concepts'
+              ? latestItemDateMs(lang, getConcepts)
+              : page === 'books'
+                ? latestItemDateMs(lang, getBooks)
+                : safeFileMtimeMs(`src/app/[lang]/${page}/page.tsx`);
       entries.push({
-        url: `${SITE_URL}/${lang}/${page}`,
-        lastModified: new Date(),
+        url,
+        lastModified: new Date(lastMs ?? globalLastModifiedMs),
         changeFrequency: 'monthly',
         priority: 0.8,
         alternates: { languages: alternates },
@@ -50,9 +116,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
       const alternates = getAlternateLanguages('papers', id);
       for (const altLang of Object.keys(alternates).filter(l => l !== 'x-default')) {
+        const lastMs = itemDateMsById(getPapers, altLang, id) ?? globalLastModifiedMs;
         entries.push({
           url: `${SITE_URL}/${altLang}/papers/${id}`,
-          lastModified: paper.frontmatter.date ? new Date(paper.frontmatter.date) : new Date(),
+          lastModified: new Date(lastMs),
           changeFrequency: 'monthly',
           priority: 0.9,
           alternates: { languages: alternates },
@@ -72,9 +139,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
       const alternates = getAlternateLanguages('articles', id);
       for (const altLang of Object.keys(alternates).filter(l => l !== 'x-default')) {
+        const lastMs = itemDateMsById(getArticles, altLang, id) ?? globalLastModifiedMs;
         entries.push({
           url: `${SITE_URL}/${altLang}/articles/${id}`,
-          lastModified: article.frontmatter.date ? new Date(article.frontmatter.date) : new Date(),
+          lastModified: new Date(lastMs),
           changeFrequency: 'monthly',
           priority: 0.9,
           alternates: { languages: alternates },
@@ -94,9 +162,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
       const alternates = getAlternateLanguages('concepts', id);
       for (const altLang of Object.keys(alternates).filter(l => l !== 'x-default')) {
+        const lastMs = itemDateMsById(getConcepts, altLang, id) ?? globalLastModifiedMs;
         entries.push({
           url: `${SITE_URL}/${altLang}/concepts/${id}`,
-          lastModified: new Date(),
+          lastModified: new Date(lastMs),
           changeFrequency: 'monthly',
           priority: 0.85,
           alternates: { languages: alternates },
@@ -116,9 +185,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
       const alternates = getAlternateLanguages('books', id);
       for (const altLang of Object.keys(alternates).filter(l => l !== 'x-default')) {
+        const lastMs = itemDateMsById(getBooks, altLang, id) ?? globalLastModifiedMs;
         entries.push({
           url: `${SITE_URL}/${altLang}/books/${id}`,
-          lastModified: book.frontmatter.date ? new Date(book.frontmatter.date) : new Date(),
+          lastModified: new Date(lastMs),
           changeFrequency: 'monthly',
           priority: 0.9,
           alternates: { languages: alternates },

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -72,7 +72,7 @@ export interface BreadcrumbItem {
 
 // ─── Site-Level Schemas ────────────────────────────────────────────────────
 
-/** WebSite + SearchAction — enables sitelinks search box */
+/** WebSite — top-level site identity */
 export function schemaWebSite() {
   return {
     '@context': 'https://schema.org',
@@ -82,14 +82,6 @@ export function schemaWebSite() {
     url: SITE_URL,
     description: 'Research platform for the Fractal Resonance Cognition framework — exploring consciousness, coherence, and quantum foundations.',
     inLanguage: 'en',
-    potentialAction: {
-      '@type': 'SearchAction',
-      target: {
-        '@type': 'EntryPoint',
-        urlTemplate: `${SITE_URL}/search?q={search_term_string}`,
-      },
-      'query-input': 'required name=search_term_string',
-    },
   };
 }
 
@@ -401,34 +393,28 @@ export function schemaDataset() {
     '@type': 'Dataset',
     '@id': `${SITE_URL}/#dataset`,
     name: 'Fractal Resonance Cognition Research Data',
-    description: 'Structured research data from the FRC framework including papers, concepts, equations, and knowledge graph relationships.',
-    url: `${SITE_URL}/for-ai`,
+    description: 'Machine-readable resources for the Fractal Resonance Cognition corpus (sitemap, LLM summary, and indexing metadata).',
+    url: `${SITE_URL}/llms.txt`,
     creator: { '@id': `${SITE_URL}/#author` },
     license: 'https://opensource.org/licenses/BSL-1.1',
     distribution: [
       {
         '@type': 'DataDownload',
-        encodingFormat: 'application/json',
-        contentUrl: `${SITE_URL}/api/concepts`,
-        name: 'FRC Concepts API',
+        encodingFormat: 'text/plain',
+        contentUrl: `${SITE_URL}/llms.txt`,
+        name: 'FRC LLM Summary',
       },
       {
         '@type': 'DataDownload',
-        encodingFormat: 'application/json',
-        contentUrl: `${SITE_URL}/api/papers`,
-        name: 'FRC Papers API',
-      },
-      {
-        '@type': 'DataDownload',
-        encodingFormat: 'application/json',
-        contentUrl: `${SITE_URL}/api/graph`,
-        name: 'FRC Knowledge Graph API',
+        encodingFormat: 'application/xml',
+        contentUrl: `${SITE_URL}/sitemap.xml`,
+        name: 'Sitemap',
       },
       {
         '@type': 'DataDownload',
         encodingFormat: 'text/plain',
-        contentUrl: `${SITE_URL}/llms.txt`,
-        name: 'FRC LLM Summary',
+        contentUrl: `${SITE_URL}/robots.txt`,
+        name: 'Robots.txt',
       },
     ],
     keywords: [


### PR DESCRIPTION
Fixes #91
Fixes #92

### Why
- Prevents sitemap churn (was using `new Date()` for many entries), which can create noisy recrawls and unstable indexing signals.
- Removes schema.org claims for features/endpoints that don't exist (site search + JSON APIs), reducing structured-data confusion.

### Changes
- `src/app/sitemap.ts`
  - Compute a stable `globalLastModified` from latest content dates (papers/articles/concepts/books) with file mtime fallbacks.
  - Use per-language content dates for detail pages instead of `new Date()`.
  - Add `x-default` hreflang for homepage and include `/[lang]/concepts` in the static page list.
- `src/lib/schema.ts`
  - Remove `SearchAction` pointing to `/search`.
  - Update `Dataset` schema to reference real machine-readable resources (`/llms.txt`, `/sitemap.xml`, `/robots.txt`).

### Validation
- `npm run validate`
- `npm run build`
