### PR TITLE
feat(ui): improve search trigger accessibility

### DIFF
--- a/src/__tests__/SearchTrigger.test.tsx
+++ b/src/__tests__/SearchTrigger.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SearchTrigger } from '../components/SearchTrigger';
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  usePathname: vi.fn(),
+}));
+
+import { usePathname } from 'next/navigation';
+
+describe('SearchTrigger', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders with accessibility attributes in English', () => {
+    (usePathname as any).mockReturnValue('/en');
+    render(<SearchTrigger />);
+
+    const button = screen.getByRole('button', { name: /search/i });
+    expect(button).toBeInTheDocument();
+
+    // Check for aria-label or name accessible name
+    expect(button).toHaveAttribute('aria-label', 'Search (Cmd+K)');
+
+    // Check for aria-keyshortcuts
+    expect(button).toHaveAttribute('aria-keyshortcuts', 'Meta+K');
+
+    // Check for title
+    expect(button).toHaveAttribute('title', 'Search (Cmd+K)');
+  });
+
+  it('renders with accessibility attributes in Farsi', () => {
+    (usePathname as any).mockReturnValue('/fa');
+    render(<SearchTrigger />);
+
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+
+    // "جستجو" is "Search" in Farsi as per DICT
+    expect(button).toHaveAttribute('aria-label', 'جستجو (Cmd+K)');
+    expect(button).toHaveAttribute('title', 'جستجو (Cmd+K)');
+  });
+});

--- a/src/components/SearchTrigger.tsx
+++ b/src/components/SearchTrigger.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useCallback } from 'react';
+import { usePathname } from 'next/navigation';
+import { getLangFromPathname } from '@/lib/site';
 
 interface SearchTriggerProps {
   className?: string;
@@ -14,6 +16,11 @@ const DICT: Record<string, string> = {
 };
 
 export function SearchTrigger({ className = '' }: SearchTriggerProps) {
+  const pathname = usePathname();
+  const lang = getLangFromPathname(pathname, 'en');
+  const label = DICT[lang] || DICT['en'];
+  const fullLabel = `${label} (Cmd+K)`;
+
   const openSearch = useCallback(() => {
     // Dispatch a keyboard event to trigger the CommandPalette (Cmd+K)
     const event = new KeyboardEvent('keydown', {
@@ -30,7 +37,9 @@ export function SearchTrigger({ className = '' }: SearchTriggerProps) {
       type="button"
       onClick={openSearch}
       className={`flex items-center gap-2 text-frc-text-dim hover:text-frc-gold transition-colors ${className}`}
-      aria-label="Open search"
+      aria-label={fullLabel}
+      title={fullLabel}
+      aria-keyshortcuts="Meta+K"
     >
       <svg
         className="w-4 h-4"


### PR DESCRIPTION
Improved the accessibility of the `SearchTrigger` component in the header.
- Added localized `aria-label` and `title` attributes that include the keyboard shortcut hint (e.g., "Search (Cmd+K)").
- Added `aria-keyshortcuts="Meta+K"` to programmatically expose the shortcut.
- Added a new test file `src/__tests__/SearchTrigger.test.tsx` to verify these attributes.
- Ensured the visual `/` hint remains but is supported by robust accessibility attributes.

---
*PR created automatically by Jules for task [5444229593087606382](https://jules.google.com/task/5444229593087606382) started by @hadsern*