### PR TITLE
⚡ Bolt: Memoize content fetching with React.cache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-13 - Missing React.cache in Content Fetching
+**Learning:** `src/lib/content.ts` functions were performing synchronous file I/O on every call without memoization, despite being called multiple times per request (e.g., `getPaper`, `buildBacklinks`, `getGlossary`). The `React.cache` wrapper was missing.
+**Action:** Wrapped all heavy data fetching functions in `src/lib/content.ts` with `React.cache` to deduplicate file reads and parsing within a request lifecycle. Always verify implementation details even if memory suggests optimization exists.

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -8,6 +8,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import { cache } from 'react';
 import type { PaperMeta, ConceptMeta } from './schema';
 
 const CONTENT_DIR = path.join(process.cwd(), 'content');
@@ -291,7 +292,7 @@ function isPublished(content: ParsedContent): boolean {
 }
 
 /** Get all papers for a language */
-export function getPapers(lang: string = 'en'): ParsedContent[] {
+export const getPapers = cache(function getPapers(lang: string = 'en'): ParsedContent[] {
   const dir = path.join(CONTENT_DIR, lang, 'papers');
   if (!fs.existsSync(dir)) return [];
 
@@ -303,10 +304,10 @@ export function getPapers(lang: string = 'en'): ParsedContent[] {
     })
     .filter(isPublished)
     .sort((a, b) => String(a.frontmatter.date || '').localeCompare(String(b.frontmatter.date || '')));
-}
+});
 
 /** Get all articles (blog/episodes) for a language */
-export function getArticles(lang: string = 'en'): ParsedContent[] {
+export const getArticles = cache(function getArticles(lang: string = 'en'): ParsedContent[] {
   const dir = path.join(CONTENT_DIR, lang, 'articles');
   if (!fs.existsSync(dir)) return [];
 
@@ -318,10 +319,10 @@ export function getArticles(lang: string = 'en'): ParsedContent[] {
     })
     .filter(isPublished)
     .sort((a, b) => String(a.frontmatter.date || '').localeCompare(String(b.frontmatter.date || '')));
-}
+});
 
 /** Get all blog posts for a language */
-export function getBlogPosts(lang: string = 'en'): ParsedContent[] {
+export const getBlogPosts = cache(function getBlogPosts(lang: string = 'en'): ParsedContent[] {
   const dir = path.join(CONTENT_DIR, lang, 'blog');
   if (!fs.existsSync(dir)) return [];
 
@@ -333,10 +334,10 @@ export function getBlogPosts(lang: string = 'en'): ParsedContent[] {
     })
     .filter(isPublished)
     .sort((a, b) => String(a.frontmatter.date || '').localeCompare(String(b.frontmatter.date || '')));
-}
+});
 
 /** Get a single blog post by id */
-export function getBlogPost(lang: string, id: string): ParsedContent | null {
+export const getBlogPost = cache(function getBlogPost(lang: string, id: string): ParsedContent | null {
   const dir = path.join(CONTENT_DIR, lang, 'blog');
   if (!fs.existsSync(dir)) return null;
 
@@ -347,10 +348,10 @@ export function getBlogPost(lang: string, id: string): ParsedContent | null {
     if (parsed.frontmatter.id === id) return parsed;
   }
   return null;
-}
+});
 
 /** Get all topics for a language */
-export function getTopics(lang: string = 'en'): ParsedContent[] {
+export const getTopics = cache(function getTopics(lang: string = 'en'): ParsedContent[] {
   const dir = path.join(CONTENT_DIR, lang, 'topics');
   if (!fs.existsSync(dir)) return [];
 
@@ -362,10 +363,10 @@ export function getTopics(lang: string = 'en'): ParsedContent[] {
     })
     .filter(isPublished)
     .sort((a, b) => String(a.frontmatter.date || '').localeCompare(String(b.frontmatter.date || '')));
-}
+});
 
 /** Get a single topic by id */
-export function getTopic(lang: string, id: string): ParsedContent | null {
+export const getTopic = cache(function getTopic(lang: string, id: string): ParsedContent | null {
   const dir = path.join(CONTENT_DIR, lang, 'topics');
   if (!fs.existsSync(dir)) return null;
 
@@ -376,10 +377,10 @@ export function getTopic(lang: string, id: string): ParsedContent | null {
     if (parsed.frontmatter.id === id) return parsed;
   }
   return null;
-}
+});
 
 /** Get all people/profiles for a language */
-export function getPeople(lang: string = 'en'): ParsedContent[] {
+export const getPeople = cache(function getPeople(lang: string = 'en'): ParsedContent[] {
   const dir = path.join(CONTENT_DIR, lang, 'people');
   if (!fs.existsSync(dir)) return [];
 
@@ -390,10 +391,10 @@ export function getPeople(lang: string = 'en'): ParsedContent[] {
       return parseFrontmatter(raw);
     })
     .sort((a, b) => String(a.frontmatter.title || '').localeCompare(String(b.frontmatter.title || '')));
-}
+});
 
 /** Get a single person/profile by id */
-export function getPerson(lang: string, id: string): ParsedContent | null {
+export const getPerson = cache(function getPerson(lang: string, id: string): ParsedContent | null {
   const dir = path.join(CONTENT_DIR, lang, 'people');
   if (!fs.existsSync(dir)) return null;
 
@@ -404,10 +405,10 @@ export function getPerson(lang: string, id: string): ParsedContent | null {
     if (parsed.frontmatter.id === id) return parsed;
   }
   return null;
-}
+});
 
 /** Get a single paper by id */
-export function getPaper(lang: string, id: string): ParsedContent | null {
+export const getPaper = cache(function getPaper(lang: string, id: string): ParsedContent | null {
   const dir = path.join(CONTENT_DIR, lang, 'papers');
   if (!fs.existsSync(dir)) return null;
 
@@ -435,9 +436,9 @@ export function getPaper(lang: string, id: string): ParsedContent | null {
     if (normalize(parsed.frontmatter.id) === requested) return parsed;
   }
   return null;
-}
+});
 
-export function getLegacyPaperIds(canonicalId: string): string[] {
+export const getLegacyPaperIds = cache(function getLegacyPaperIds(canonicalId: string): string[] {
   const out: string[] = [];
   const push = (s: string) => {
     if (!s) return;
@@ -459,10 +460,10 @@ export function getLegacyPaperIds(canonicalId: string): string[] {
   push(`FRC-${series}.${suffix}`);
 
   return out;
-}
+});
 
 /** Get all books for a language */
-export function getBooks(lang: string = 'en'): ParsedContent[] {
+export const getBooks = cache(function getBooks(lang: string = 'en'): ParsedContent[] {
   const dir = path.join(CONTENT_DIR, lang, 'books');
   if (!fs.existsSync(dir)) return [];
 
@@ -492,10 +493,10 @@ export function getBooks(lang: string = 'en'): ParsedContent[] {
   }
 
   return books.sort((a, b) => String(a.frontmatter.date || '').localeCompare(String(b.frontmatter.date || '')));
-}
+});
 
 /** Get a single book by id */
-export function getBook(lang: string, id: string): ParsedContent | null {
+export const getBook = cache(function getBook(lang: string, id: string): ParsedContent | null {
   const dir = path.join(CONTENT_DIR, lang, 'books');
   if (!fs.existsSync(dir)) return null;
 
@@ -527,7 +528,7 @@ export function getBook(lang: string, id: string): ParsedContent | null {
   if (sortedChapters.length === 0) return null;
   const raw = fs.readFileSync(path.join(bookDir, sortedChapters[0]), 'utf-8');
   return parseFrontmatter(raw);
-}
+});
 
 export interface BookChapter {
   filename: string;
@@ -535,7 +536,7 @@ export interface BookChapter {
   body: string;
 }
 
-export function getBookChapters(lang: string, id: string): BookChapter[] {
+export const getBookChapters = cache(function getBookChapters(lang: string, id: string): BookChapter[] {
   const bookDir = path.join(CONTENT_DIR, lang, 'books', id);
   if (!fs.existsSync(bookDir) || !fs.statSync(bookDir).isDirectory()) return [];
 
@@ -567,7 +568,7 @@ export function getBookChapters(lang: string, id: string): BookChapter[] {
       extractTitleFromBody(parsed.body, fallbackTitle);
     return { filename, title, body: parsed.body };
   });
-}
+});
 
 /**
  * Sort chapter filenames in proper book order:
@@ -630,7 +631,7 @@ function romanOrNumToInt(val: string): number {
 }
 
 /** Get all concepts for a language */
-export function getConcepts(lang: string = 'en'): ParsedContent[] {
+export const getConcepts = cache(function getConcepts(lang: string = 'en'): ParsedContent[] {
   const dir = path.join(CONTENT_DIR, lang, 'concepts');
   if (!fs.existsSync(dir)) return [];
 
@@ -641,10 +642,10 @@ export function getConcepts(lang: string = 'en'): ParsedContent[] {
       return parseFrontmatter(raw);
     })
     .filter(isPublished);
-}
+});
 
 /** Get a single concept by id */
-export function getConcept(lang: string, id: string): ParsedContent | null {
+export const getConcept = cache(function getConcept(lang: string, id: string): ParsedContent | null {
   const dir = path.join(CONTENT_DIR, lang, 'concepts');
   if (!fs.existsSync(dir)) return null;
 
@@ -655,19 +656,19 @@ export function getConcept(lang: string, id: string): ParsedContent | null {
     if (parsed.frontmatter.id === id) return parsed;
   }
   return null;
-}
+});
 
 /** Get all available languages */
-export function getLanguages(): string[] {
+export const getLanguages = cache(function getLanguages(): string[] {
   if (!fs.existsSync(CONTENT_DIR)) return ['en'];
   return fs.readdirSync(CONTENT_DIR)
     .filter(f => {
       const full = path.join(CONTENT_DIR, f);
       return fs.statSync(full).isDirectory() && f !== 'inbox';
     });
-}
+});
 
-export function getHomeConfig(lang: string = 'en'): HomeConfig | null {
+export const getHomeConfig = cache(function getHomeConfig(lang: string = 'en'): HomeConfig | null {
   // Keep home CMS config outside normal content types.
   const tryPaths = [
     path.join(CONTENT_DIR, lang, 'site', 'home.md'),
@@ -686,10 +687,10 @@ export function getHomeConfig(lang: string = 'en'): HomeConfig | null {
   }
 
   return null;
-}
+});
 
 /** Get a single site page (investors, contact, etc.) */
-export function getSitePage(lang: string, slug: string): ParsedContent | null {
+export const getSitePage = cache(function getSitePage(lang: string, slug: string): ParsedContent | null {
   const p = path.join(CONTENT_DIR, lang, 'site', `${slug}.md`);
   if (!fs.existsSync(p)) {
     // Fallback to English if not found in requested language
@@ -698,10 +699,10 @@ export function getSitePage(lang: string, slug: string): ParsedContent | null {
     return parseFrontmatter(fs.readFileSync(fallback, 'utf-8'));
   }
   return parseFrontmatter(fs.readFileSync(p, 'utf-8'));
-}
+});
 
 /** Get a single article by id */
-export function getArticle(lang: string, id: string): ParsedContent | null {
+export const getArticle = cache(function getArticle(lang: string, id: string): ParsedContent | null {
   const dir = path.join(CONTENT_DIR, lang, 'articles');
   if (!fs.existsSync(dir)) return null;
 
@@ -712,7 +713,7 @@ export function getArticle(lang: string, id: string): ParsedContent | null {
     if (parsed.frontmatter.id === id) return parsed;
   }
   return null;
-}
+});
 
 // ─── Schema Converters ─────────────────────────────────────────────────────
 
@@ -869,7 +870,7 @@ export function matchesPerspectiveView(p: unknown, view: PerspectiveView): boole
 }
 
 /** Get a glossary map of all content for tooltips */
-export function getGlossary(
+export const getGlossary = cache(function getGlossary(
   lang: string = 'en',
   opts?: { basePath?: string; view?: PerspectiveView }
 ): Record<string, GlossaryItem> {
@@ -991,12 +992,12 @@ export function getGlossary(
   }
 
   return glossary;
-}
+});
 
 // ─── Tag Processing ────────────────────────────────────────────────────────
 
 /** Get all unique tags across all content */
-export function getAllTags(lang: string = 'en'): string[] {
+export const getAllTags = cache(function getAllTags(lang: string = 'en'): string[] {
   const papers = getPapers(lang);
   const concepts = getConcepts(lang);
   const books = getBooks(lang);
@@ -1012,10 +1013,10 @@ export function getAllTags(lang: string = 'en'): string[] {
   });
 
   return Array.from(tags).sort();
-}
+});
 
 /** Get all content items that have a specific tag */
-export function getContentsByTag(lang: string, tag: string): ParsedContent[] {
+export const getContentsByTag = cache(function getContentsByTag(lang: string, tag: string): ParsedContent[] {
   const papers = getPapers(lang);
   const concepts = getConcepts(lang);
   const books = getBooks(lang);
@@ -1035,7 +1036,7 @@ export function getContentsByTag(lang: string, tag: string): ParsedContent[] {
       if (dateA && dateB) return dateB.localeCompare(dateA);
       return a.frontmatter.title.localeCompare(b.frontmatter.title);
     });
-}
+});
 
 // ─── Graph Generation ──────────────────────────────────────────────────────
 
@@ -1057,7 +1058,7 @@ export interface GraphData {
 }
 
 /** Generate graph data for visualization */
-export function getGraphData(lang: string = 'en', view: PerspectiveView = 'kasra'): GraphData {
+export const getGraphData = cache(function getGraphData(lang: string = 'en', view: PerspectiveView = 'kasra'): GraphData {
   const nodes: GraphNode[] = [];
   const links: GraphLink[] = [];
   const nodeIds = new Set<string>();
@@ -1122,7 +1123,7 @@ export function getGraphData(lang: string = 'en', view: PerspectiveView = 'kasra
   }
 
   return { nodes, links };
-}
+});
 
 function canonicalizeFrcLikeIdForGraph(raw: string): string {
   const s = String(raw || '').trim();
@@ -1267,7 +1268,7 @@ export interface ContentStats {
 }
 
 /** Get content statistics for a language */
-export function getContentStats(lang: string = 'en'): ContentStats {
+export const getContentStats = cache(function getContentStats(lang: string = 'en'): ContentStats {
   const papers = getPapers(lang);
   const seriesSet = new Set<string>();
 
@@ -1291,12 +1292,12 @@ export function getContentStats(lang: string = 'en'): ContentStats {
     blog: getBlogPosts(lang).length,
     people: getPeople(lang).length,
   };
-}
+});
 
 // ─── Backlinks ──────────────────────────────────────────────────────────────
 
 /** Build backlinks index: { targetId: [sourceIds] } */
-export function buildBacklinks(lang: string = 'en', view: PerspectiveView = 'kasra'): Record<string, string[]> {
+export const buildBacklinks = cache(function buildBacklinks(lang: string = 'en', view: PerspectiveView = 'kasra'): Record<string, string[]> {
   const backlinks: Record<string, string[]> = {};
   const papers = getPapers(lang);
   const concepts = getConcepts(lang);
@@ -1324,4 +1325,4 @@ export function buildBacklinks(lang: string = 'en', view: PerspectiveView = 'kas
   }
 
   return backlinks;
-}
+});


### PR DESCRIPTION
💡 What: Wrapped content fetching functions in `src/lib/content.ts` with `React.cache`.
🎯 Why: To deduplicate file system reads and frontmatter parsing when multiple components or functions request the same data within a single request (e.g., `PaperPage` calling `buildBacklinks` and `getGlossary`).
📊 Impact: Reduces redundant file I/O and CPU usage during page generation.
🔬 Measurement: Verified with unit tests that `cache` works correctly.

---
*PR created automatically by Jules for task [16763858409644597821](https://jules.google.com/task/16763858409644597821) started by @hadsern*