### PR TITLE
🛡️ Sentinel: [HIGH] Fix ReDoS Vulnerability in Search API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-28 - [ReDoS Vulnerability in Search API]
+**Vulnerability:** Unescaped user input used in RegExp constructor inside `scoreDocument` function in `functions/api/ask.ts`. An attacker could pass a crafted string (e.g. `[`) which would cause a regex compilation error, resulting in a Denial of Service (500 Internal Server Error) for the `/api/ask` endpoint. Additionally, complex malicious regex patterns could potentially cause ReDoS (Regular Expression Denial of Service) by consuming excessive CPU time.
+**Learning:** Even internal helper functions need to validate and sanitize parameters that originate from user input. Creating `new RegExp(user_input)` without escaping is a critical security vulnerability.
+**Prevention:** Always escape user input before using it to construct a RegExp dynamically. Alternatively, use a safer string matching method if regex features are not needed. We should create a `escapeRegExp` utility function or use a built-in one.

--- a/functions/api/ask.ts
+++ b/functions/api/ask.ts
@@ -38,6 +38,10 @@ interface AskRequest {
   limit?: number;
 }
 
+function escapeRegExp(string: string): string {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}
+
 // Simple relevance scoring based on term frequency
 function scoreDocument(doc: SearchDocument, terms: string[]): number {
   let score = 0;
@@ -54,7 +58,8 @@ function scoreDocument(doc: SearchDocument, terms: string[]): number {
     // Tag match (high weight)
     if (tagsLower.some(t => t.includes(term))) score += 5;
     // Content match (count occurrences)
-    const contentMatches = (contentLower.match(new RegExp(term, 'g')) || []).length;
+    const safeTerm = escapeRegExp(term);
+    const contentMatches = (contentLower.match(new RegExp(safeTerm, 'g')) || []).length;
     score += Math.min(contentMatches, 5); // Cap at 5 to avoid bias toward long docs
   }
 
@@ -137,6 +142,13 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 
     if (!query || typeof query !== 'string') {
       return new Response(JSON.stringify({ error: 'Query is required' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (query.length > 500) {
+      return new Response(JSON.stringify({ error: 'Query exceeds maximum length of 500 characters' }), {
         status: 400,
         headers: { 'Content-Type': 'application/json' },
       });


### PR DESCRIPTION
This PR fixes a high severity Regular Expression Denial of Service (ReDoS) vulnerability in the Cloudflare Pages Function at `functions/api/ask.ts`.

### Details:
1. **RegExp Injection**: The `scoreDocument` function dynamically constructs regular expressions using `new RegExp(term, 'g')` where `term` comes directly from the user's search query. Without proper escaping, special characters (like `[`, `(`, `+`, `?`) break the execution and cause a `500 Internal Server Error`, or worse, complex malicious strings can tie up the CPU leading to ReDoS. I've introduced an `escapeRegExp` utility to escape all regex special characters.
2. **Query Length Limit**: The API accepted arbitrarily long strings. To prevent excessive memory consumption and further mitigate ReDoS risks, a hard limit of 500 characters has been implemented for incoming search queries.
3. **Journal Updated**: I've added a note to `.jules/sentinel.md` documenting this finding.

---
*PR created automatically by Jules for task [14036444735310709242](https://jules.google.com/task/14036444735310709242) started by @hadsern*