### PR TITLE
🛡️ Sentinel: [HIGH] Fix JSON.stringify XSS in SchemaScript

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - JSON-LD Script Injection via JSON.stringify
+**Vulnerability:** XSS vulnerability in `<script>` tags rendering JSON. `JSON.stringify` does not escape HTML control characters like `<` or `>`. When its output is placed in a `<script>` tag via `dangerouslySetInnerHTML`, a malicious string containing `</script>` can break out of the script tag and execute arbitrary JS.
+**Learning:** Never assume `JSON.stringify` output is safe for raw HTML injection in a script block. HTML context requires its own escaping rules independent of valid JSON syntax.
+**Prevention:** Always manually replace `<` with `\u003c` and `>` with `\u003e` (and optionally `&` and `\u2028`, `\u2029`) when interpolating JSON directly into script tags.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -2,8 +2,8 @@
  * SchemaScript — renders JSON-LD structured data in a <script> tag.
  *
  * Safety: All data comes from typed schema generators in src/lib/schema.ts.
- * No user input is ever passed to this component. The JSON.stringify output
- * is always valid JSON with no HTML special characters unescaped.
+ * We manually escape HTML control characters after JSON.stringify to prevent
+ * XSS in case user input or external data ever makes its way into the schema.
  *
  * Usage:
  *   <SchemaScript data={schemaSiteGraph()} />
@@ -15,10 +15,12 @@ interface SchemaScriptProps {
 }
 
 export function SchemaScript({ data }: SchemaScriptProps) {
-  // JSON.stringify produces safe output for script tags — it escapes
-  // forward slashes and special characters. No HTML injection possible
-  // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // JSON.stringify does NOT automatically escape HTML control characters.
+  // We must manually escape < and > to prevent XSS if schema data contains
+  // malicious strings like "</script><script>alert(1)</script>".
+  const jsonLd = JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e');
 
   return (
     <script


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: XSS vulnerability in `<script>` tags rendering JSON. `JSON.stringify` does not escape HTML control characters like `<` or `>`. When its output is placed in a `<script>` tag via `dangerouslySetInnerHTML`, a malicious string containing `</script>` can break out of the script tag and execute arbitrary JS.
🎯 **Impact**: If any user-controlled string (like a page title or author name) containing a malicious script tag makes its way into the schema data, it could execute arbitrary JavaScript in the victim's browser context.
🔧 **Fix**: Manually replace `<` with `\u003c` and `>` with `\u003e` in the serialized JSON string before injecting it into the HTML context.
✅ **Verification**: Run `bun test` to ensure tests still pass, and verify the `jsonLd` string replacements in `src/components/SchemaScript.tsx` properly escape control characters. Also documented this pattern in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [1860124548526841510](https://jules.google.com/task/1860124548526841510) started by @hadsern*