### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in SchemaScript JSON-LD injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-01 - JSON.stringify XSS Vulnerability in Script Tags
+**Vulnerability:** XSS via `JSON.stringify` injected into `<script>` tags using `dangerouslySetInnerHTML`. The code wrongly assumed `JSON.stringify` produced completely safe output.
+**Learning:** `JSON.stringify` does not escape HTML control characters like `<` and `>`. If a malicious string contains `</script><script>alert(1)</script>`, it breaks out of the context.
+**Prevention:** Always escape `<` to `\u003c`, `>` to `\u003e`, and `&` to `\u0026` after `JSON.stringify` when injecting directly into a script tag context.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -2,8 +2,8 @@
  * SchemaScript — renders JSON-LD structured data in a <script> tag.
  *
  * Safety: All data comes from typed schema generators in src/lib/schema.ts.
- * No user input is ever passed to this component. The JSON.stringify output
- * is always valid JSON with no HTML special characters unescaped.
+ * We also sanitize the JSON output by escaping HTML control characters
+ * to prevent potential XSS injection if markdown content gets into schema.
  *
  * Usage:
  *   <SchemaScript data={schemaSiteGraph()} />
@@ -15,10 +15,13 @@ interface SchemaScriptProps {
 }
 
 export function SchemaScript({ data }: SchemaScriptProps) {
-  // JSON.stringify produces safe output for script tags — it escapes
-  // forward slashes and special characters. No HTML injection possible
-  // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // JSON.stringify does NOT automatically escape HTML control characters like < and >.
+  // We must explicitly escape them to prevent XSS attacks when injecting into script tags.
+  // Using \u003c, \u003e, \u0026 ensures it remains valid JSON but cannot break out of the script block.
+  const jsonLd = JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
 
   return (
     <script


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `JSON.stringify` does not escape HTML control characters like `<` and `>`. Injecting its output directly into `<script>` tags using `dangerouslySetInnerHTML` allows for potential XSS. If any unsanitized data (e.g. from markdown titles) makes its way into the `data` payload, an attacker could break out of the script tag using `</script><script>alert(1)</script>`.
🎯 Impact: Attackers could inject arbitrary JavaScript if user-controlled or external data is parsed into the JSON-LD schemas, leading to a Cross-Site Scripting (XSS) vulnerability.
🔧 Fix: Used `.replace()` to convert `<` to `\u003c`, `>` to `\u003e`, and `&` to `\u0026` in the `JSON.stringify` output before rendering it in the DOM. Also added a critical learning entry to `.jules/sentinel.md`.
✅ Verification: Ran `pnpm test` and `pnpm build` to verify the code is syntactically valid and no regressions were introduced.

---
*PR created automatically by Jules for task [13431829084973073397](https://jules.google.com/task/13431829084973073397) started by @hadsern*