### PR TITLE
🎨 Palette: Add visible focus rings to header buttons

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -51,7 +51,7 @@ export function LanguageSelector() {
     <div ref={menuRef} className="relative">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-1.5 font-mono text-[0.625rem] text-frc-steel hover:text-frc-gold tracking-wider uppercase transition-colors motion-reduce:transition-none px-2 py-2 sm:px-0 sm:py-0"
+        className="flex items-center gap-1.5 font-mono text-[0.625rem] text-frc-steel hover:text-frc-gold tracking-wider uppercase transition-colors motion-reduce:transition-none px-2 py-2 sm:px-0 sm:py-0 focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none"
         aria-label="Select language"
         aria-expanded={isOpen}
       >

--- a/src/components/SearchTrigger.tsx
+++ b/src/components/SearchTrigger.tsx
@@ -29,7 +29,7 @@ export function SearchTrigger({ className = '' }: SearchTriggerProps) {
     <button
       type="button"
       onClick={openSearch}
-      className={`flex items-center gap-2 text-frc-text-dim hover:text-frc-gold transition-colors ${className}`}
+      className={`flex items-center gap-2 text-frc-text-dim hover:text-frc-gold transition-colors focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none ${className}`}
       aria-label="Open search"
     >
       <svg

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -18,7 +18,7 @@ export function ThemeToggle() {
   return (
     <button
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
-      className="text-frc-steel hover:text-frc-gold transition-colors motion-reduce:transition-none p-2 sm:p-0.5"
+      className="text-frc-steel hover:text-frc-gold transition-colors motion-reduce:transition-none p-2 sm:p-0.5 focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none"
       aria-label={`Switch to ${isDark ? 'light' : 'dark'} theme`}
       title={`Switch to ${isDark ? 'light' : 'dark'} theme`}
     >


### PR DESCRIPTION
💡 **What:** Added visible focus rings using Tailwind (`focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none`) to the main header buttons: `ThemeToggle`, `SearchTrigger`, and `LanguageSelector`.

🎯 **Why:** Keyboard users lacked clear visual feedback when tabbing through the primary navigation actions. This ensures the focus state is accessible and consistent with the application's design tokens.

♿ **Accessibility:** Enhances WCAG compliance for focus visibility (2.4.7 Focus Visible), specifically utilizing the `focus-visible` pseudo-class to avoid mouse click side-effects while guaranteeing keyboard users see the `frc-gold` indicator.

---
*PR created automatically by Jules for task [12175387920743664240](https://jules.google.com/task/12175387920743664240) started by @hadsern*