### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in SchemaScript.tsx

### DIFF
--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -15,10 +15,12 @@ interface SchemaScriptProps {
 }
 
 export function SchemaScript({ data }: SchemaScriptProps) {
-  // JSON.stringify produces safe output for script tags — it escapes
-  // forward slashes and special characters. No HTML injection possible
-  // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // JSON.stringify by itself DOES NOT escape HTML control characters like < and >.
+  // To prevent XSS vulnerabilities when injecting JSON into script tags via dangerouslySetInnerHTML,
+  // we must manually escape these characters.
+  const jsonLd = JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e');
 
   return (
     <script


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Cross-Site Scripting (XSS) via `dangerouslySetInnerHTML`. The `JSON.stringify` output used in `SchemaScript.tsx` did not automatically escape HTML control characters like `<` and `>`. If unsanitized data were present, an attacker could prematurely close the script tag and inject arbitrary JavaScript.
🎯 **Impact:** Potential execution of malicious scripts if user-controlled or malicious data makes its way into the schema generation.
🔧 **Fix:** Replaced `<` and `>` in the stringified JSON with their respective Unicode escape sequences (`\u003c` and `\u003e`). This safely prevents HTML injection while producing perfectly valid JSON for parsers.
✅ **Verification:** Verified by running `pnpm test` and `pnpm build`. No regressions were introduced.

---
*PR created automatically by Jules for task [7997660711044615690](https://jules.google.com/task/7997660711044615690) started by @hadsern*