### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XSS in SchemaScript JSON-LD injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-17 - XSS Vulnerability in JSON-LD Script Injection
+**Vulnerability:** The application was vulnerable to Cross-Site Scripting (XSS) due to unsafe injection of JSON into a `<script>` tag via `dangerouslySetInnerHTML`. The developer incorrectly assumed `JSON.stringify` produced safe output.
+**Learning:** `JSON.stringify` does **not** automatically escape HTML control characters like `<` and `>`. If an attacker can control any data within the serialized JSON, they can include an unescaped `</script>` tag, followed by their own `<script>` block, thereby achieving arbitrary script execution within the DOM.
+**Prevention:** Whenever injecting JSON into a `<script>` tag (e.g., for JSON-LD schemas or passing state to the client), the result of `JSON.stringify` must be manually sanitized by replacing `<` with `\u003c` and `>` with `\u003e`. Alternatively, one can use a library designed for this, such as `serialize-javascript`.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -15,10 +15,13 @@ interface SchemaScriptProps {
 }
 
 export function SchemaScript({ data }: SchemaScriptProps) {
-  // JSON.stringify produces safe output for script tags — it escapes
-  // forward slashes and special characters. No HTML injection possible
-  // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // JSON.stringify by itself is NOT safe for script tags, because it does
+  // not escape HTML control characters like < and >. An attacker could
+  // supply a string containing </script><script>alert(1)</script> and
+  // execute arbitrary code. We must manually escape these characters.
+  const jsonLd = JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e');
 
   return (
     <script


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The `SchemaScript.tsx` component used `JSON.stringify` directly in `dangerouslySetInnerHTML` for a `<script>` tag. Since `JSON.stringify` does not escape HTML control characters like `<` and `>`, an attacker could inject closing tags like `</script>` via schema data and execute arbitrary code.
🎯 **Impact**: Potential Cross-Site Scripting (XSS) if any user-influenced data becomes part of the generated schema.
🔧 **Fix**: Added explicit `.replace(/</g, '\\u003c')` and `.replace(/>/g, '\\u003e')` after serialization to safely escape all HTML control characters. Also documented this critical finding in `.jules/sentinel.md`.
✅ **Verification**: Code verified. Ran `pnpm test` and `pnpm build` and ensured no regressions in rendering. Checked memory to ensure artifacts generated were reverted before submit.

---
*PR created automatically by Jules for task [7698142543716158072](https://jules.google.com/task/7698142543716158072) started by @hadsern*