### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in SchemaScript JSON-LD injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - XSS Vulnerability in JSON-LD Script Injection
+**Vulnerability:** XSS via unescaped HTML characters in JSON.stringify injected into <script> tag via dangerouslySetInnerHTML.
+**Learning:** `JSON.stringify` does not automatically escape HTML control characters like `<`, `>`, and `&`. If user-provided or dynamically generated data within the JSON contains a closing `</script>` tag, the browser will immediately terminate the script block and execute any trailing code, leading to XSS. This is true even for structured data like JSON-LD.
+**Prevention:** Whenever injecting JSON into a `<script>` tag, ALWAYS manually escape HTML control characters by chaining `.replace(/</g, '\\u003c').replace(/>/g, '\\u003e').replace(/&/g, '\\u0026')` to the `JSON.stringify()` output, or use a secure serialization library like `serialize-javascript`.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -15,10 +15,13 @@ interface SchemaScriptProps {
 }
 
 export function SchemaScript({ data }: SchemaScriptProps) {
-  // JSON.stringify produces safe output for script tags — it escapes
-  // forward slashes and special characters. No HTML injection possible
-  // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // JSON.stringify by itself is NOT safe for script tags. It does not escape
+  // <, >, or &, which can lead to XSS if a payload contains </script><script>...
+  // We must manually escape these HTML control characters.
+  const jsonLd = JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
 
   return (
     <script


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: XSS via unescaped HTML characters in JSON.stringify injected into <script> tag via dangerouslySetInnerHTML.
🎯 Impact: Could allow an attacker to inject malicious scripts if any schema data contains </script><script>...
🔧 Fix: Manually escaped <, >, and & characters in the serialized JSON string.
✅ Verification: Verified via running tests, linting, and building the project. Checked code review.

---
*PR created automatically by Jules for task [8740279582614413973](https://jules.google.com/task/8740279582614413973) started by @hadsern*