### PR TITLE
🎨 Palette: Add visible keyboard focus states to header controls

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -51,7 +51,7 @@ export function LanguageSelector() {
     <div ref={menuRef} className="relative">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-1.5 font-mono text-[0.625rem] text-frc-steel hover:text-frc-gold tracking-wider uppercase transition-colors motion-reduce:transition-none px-2 py-2 sm:px-0 sm:py-0"
+        className="flex items-center gap-1.5 font-mono text-[0.625rem] text-frc-steel hover:text-frc-gold tracking-wider uppercase transition-colors motion-reduce:transition-none px-2 py-2 sm:px-0 sm:py-0 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-frc-gold"
         aria-label="Select language"
         aria-expanded={isOpen}
       >

--- a/src/components/SearchTrigger.tsx
+++ b/src/components/SearchTrigger.tsx
@@ -29,7 +29,7 @@ export function SearchTrigger({ className = '' }: SearchTriggerProps) {
     <button
       type="button"
       onClick={openSearch}
-      className={`flex items-center gap-2 text-frc-text-dim hover:text-frc-gold transition-colors ${className}`}
+      className={`flex items-center gap-2 text-frc-text-dim hover:text-frc-gold transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-frc-gold ${className}`}
       aria-label="Open search"
     >
       <svg

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -18,7 +18,7 @@ export function ThemeToggle() {
   return (
     <button
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
-      className="text-frc-steel hover:text-frc-gold transition-colors motion-reduce:transition-none p-2 sm:p-0.5"
+      className="text-frc-steel hover:text-frc-gold transition-colors motion-reduce:transition-none p-2 sm:p-0.5 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-frc-gold"
       aria-label={`Switch to ${isDark ? 'light' : 'dark'} theme`}
       title={`Switch to ${isDark ? 'light' : 'dark'} theme`}
     >


### PR DESCRIPTION
💡 **What:** Added visible focus states (`focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded-sm`) to interactive header controls (`LanguageSelector`, `SearchTrigger`, `ThemeToggle`).

🎯 **Why:** Keyboard users navigating the site lacked clear visual indicators of their current focus when tabbing through the top navigation bar. This improves the overall accessibility and discoverability of these primary actions.

📸 **Before/After:** (Tested locally via Playwright headless navigation—gold rings clearly encircle the active element).

♿ **Accessibility:** Enhances WCAG 2.4.7 Focus Visible compliance for key interactive elements. Changes kept strictly under 50 lines.

---
*PR created automatically by Jules for task [1662525021467404143](https://jules.google.com/task/1662525021467404143) started by @hadsern*