### PR TITLE
🎨 Palette: Replace default browser <details> marker with custom animated chevron

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-09 - Collapsible Section Markers
+**Learning:** Collapsible sections implemented with `<details>` and `<summary>` require the `list-none` class and `[&::-webkit-details-marker]:hidden` to remove the default browser triangle marker. They also require visual indicators (e.g., a chevron) and utilize Tailwind's `group` and `group-open` modifiers for state-based styling.
+**Action:** When working with `<details>`/`<summary>`, verify that the default triangle is hidden and a custom visual indicator with state modifiers (`group`, `group-open`) is implemented.

--- a/src/components/InlineToc.tsx
+++ b/src/components/InlineToc.tsx
@@ -16,9 +16,17 @@ export function InlineToc({
   const hideClass = hideAt === 'lg' ? 'lg:hidden' : hideAt === 'xl' ? 'xl:hidden' : '2xl:hidden';
 
   return (
-    <details className={`${hideClass} mb-6 border border-frc-blue rounded-lg ${className}`}>
-      <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none">
+    <details className={`${hideClass} group mb-6 border border-frc-blue rounded-lg ${className}`}>
+      <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden flex items-center justify-between">
         <span className="text-xs uppercase tracking-wider text-frc-steel">{title}</span>
+        <svg
+          className="w-4 h-4 text-frc-steel transition-transform duration-200 group-open:rotate-180"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
       </summary>
       <nav className="px-4 pb-4">
         <ul className="space-y-1 text-sm">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -80,9 +80,17 @@ export function Sidebar({ lang, currentId, basePath, view, variant = 'desktop' }
   return (
     <aside data-sidebar className={asideClass}>
       {isMobile ? (
-        <details>
-          <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none">
+        <details className="group">
+          <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden flex items-center justify-between">
             <span className="text-xs uppercase tracking-wider text-frc-steel">Browse library</span>
+            <svg
+              className="w-4 h-4 text-frc-steel transition-transform duration-200 group-open:rotate-180"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
           </summary>
           {nav}
         </details>
@@ -124,9 +132,19 @@ function SidebarSection({
   });
 
   return (
-    <details open={openByDefault} className="mb-4">
-      <summary className="flex items-center justify-between gap-3 text-xs uppercase tracking-wider text-frc-steel px-2 cursor-pointer select-none list-none">
-        <span>{title}</span>
+    <details open={openByDefault} className="group mb-4">
+      <summary className="flex items-center justify-between gap-3 text-xs uppercase tracking-wider text-frc-steel px-2 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
+        <span className="flex items-center gap-2">
+          {title}
+          <svg
+            className="w-3.5 h-3.5 text-frc-steel transition-transform duration-200 group-open:rotate-180"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </span>
         <span className="text-[11px] normal-case text-frc-text-dim">{sorted.length}</span>
       </summary>
       <ul className="space-y-0.5 mt-2 max-h-64 overflow-y-auto pr-1">


### PR DESCRIPTION
💡 **What**: Replaced the default browser `<details>` summary marker (triangle) with a custom, animated SVG chevron on both the `Sidebar` and `InlineToc` components.
🎯 **Why**: The default browser marker looks slightly different on every browser/OS and can appear unpolished. Using a standard chevron that smoothly rotates (via Tailwind's `group-open:rotate-180`) provides an immediate, polished interaction, indicating visually to the user whether the container is open or closed, standardizing the aesthetic across views.
📸 **Before/After**: The default browser-rendered right-facing triangle is hidden. Instead, a custom chevron-down SVG is displayed inline alongside the text. When expanded, this chevron rotates cleanly 180 degrees.
♿ **Accessibility**: The solution relies strictly on native browser `<details>` and `<summary>` behaviors for structural keyboard nav and semantics, simply swapping the visual indicator. The class `list-none [&::-webkit-details-marker]:hidden` safely conceals the default un-stylable marker without losing native `summary` focus abilities.

---
*PR created automatically by Jules for task [1115300705760608367](https://jules.google.com/task/1115300705760608367) started by @hadsern*