### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in SchemaScript

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-09 - XSS Vulnerability in SchemaScript with JSON.stringify
+**Vulnerability:** XSS vulnerability when injecting JSON into `<script>` tags via `dangerouslySetInnerHTML`. `JSON.stringify` does not escape HTML control characters like `<` and `>`.
+**Learning:** Even if data is typed and generated internally, injecting raw JSON into `<script>` tags without escaping HTML control characters can lead to premature script tag closure and XSS if any data field contains user-controlled input or unexpectedly contains HTML.
+**Prevention:** Always manually escape `<` and `>` when injecting `JSON.stringify` output into HTML script tags using `.replace(/</g, '\\u003c').replace(/>/g, '\\u003e')`.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -16,9 +16,10 @@ interface SchemaScriptProps {
 
 export function SchemaScript({ data }: SchemaScriptProps) {
   // JSON.stringify produces safe output for script tags — it escapes
-  // forward slashes and special characters. No HTML injection possible
-  // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // forward slashes and special characters. We also manually escape
+  // HTML control characters (< and >) to prevent XSS attacks when
+  // injecting into script tags via dangerouslySetInnerHTML.
+  const jsonLd = JSON.stringify(data).replace(/</g, '\\u003c').replace(/>/g, '\\u003e');
 
   return (
     <script


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** XSS vulnerability when injecting `JSON.stringify` output into `<script>` tags via `dangerouslySetInnerHTML`. Because `JSON.stringify` does not escape HTML control characters (`<` and `>`), any payload containing a sequence like `</script><script>alert(1)</script>` could prematurely close the intended script tag and execute arbitrary code.
🎯 **Impact:** If any portion of the schema data contained unsanitized user inputs or unexpectedly included an end-script HTML tag, an attacker could execute arbitrary JavaScript within the user's browser in the context of the website.
🔧 **Fix:** Added `.replace(/</g, '\\u003c').replace(/>/g, '\\u003e')` immediately after `JSON.stringify(data)` in `SchemaScript.tsx`. This manually escapes HTML control characters into their safe unicode escape sequences. The JSON payload remains perfectly valid but the browser's HTML parser is prevented from misinterpreting embedded tags. Also documented the learning in `.jules/sentinel.md`.
✅ **Verification:** Ran `pnpm test` and `pnpm build` to verify functionality. Verified the source code manually. Requesting final review.

---
*PR created automatically by Jules for task [249588733389388629](https://jules.google.com/task/249588733389388629) started by @hadsern*