### PR TITLE
🎨 Palette: Add keyboard focus rings to navigation buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-10 - Standard Keyboard Focus Styles Missing
+**Learning:** Found that many interactive elements (like buttons) across the repository lack proper keyboard focus rings. A memory mentions the standard Tailwind styling used to ensure visible, accessible keyboard focus rings on interactive elements is `focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none`.
+**Action:** Will update buttons and other interactive elements to use this pattern.

--- a/src/components/PerspectiveToggle.tsx
+++ b/src/components/PerspectiveToggle.tsx
@@ -30,7 +30,8 @@ export function PerspectiveToggle() {
           key={p.value}
           onClick={() => router.push(togglePerspectivePathname(pathname, p.value))}
           className={`
-            px-2 py-1 rounded transition-all duration-200
+            px-2 py-1 transition-all duration-200
+            focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-frc-gold rounded-sm
             ${perspective === p.value
               ? 'bg-frc-gold/20 text-frc-gold'
               : 'text-frc-steel hover:text-frc-text-dim'
@@ -63,7 +64,7 @@ export function PerspectiveToggleCompact() {
   return (
     <button
       onClick={toggle}
-      className="flex items-center gap-1 text-xs text-frc-steel hover:text-frc-gold transition-colors"
+      className="flex items-center gap-1 text-xs text-frc-steel hover:text-frc-gold transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-frc-gold"
       title={`Switch to ${other}'s perspective`}
     >
       <span>{current.icon}</span>

--- a/src/components/SearchTrigger.tsx
+++ b/src/components/SearchTrigger.tsx
@@ -29,7 +29,7 @@ export function SearchTrigger({ className = '' }: SearchTriggerProps) {
     <button
       type="button"
       onClick={openSearch}
-      className={`flex items-center gap-2 text-frc-text-dim hover:text-frc-gold transition-colors ${className}`}
+      className={`flex items-center gap-2 text-frc-text-dim hover:text-frc-gold transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-frc-gold ${className}`}
       aria-label="Open search"
     >
       <svg

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -18,7 +18,7 @@ export function ThemeToggle() {
   return (
     <button
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
-      className="text-frc-steel hover:text-frc-gold transition-colors motion-reduce:transition-none p-2 sm:p-0.5"
+      className="text-frc-steel hover:text-frc-gold transition-colors motion-reduce:transition-none p-2 sm:p-0.5 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-frc-gold"
       aria-label={`Switch to ${isDark ? 'light' : 'dark'} theme`}
       title={`Switch to ${isDark ? 'light' : 'dark'} theme`}
     >


### PR DESCRIPTION
💡 What: Added standard `focus-visible` styling to prominent top-nav buttons (`ThemeToggle`, `SearchTrigger`, `PerspectiveToggle`).
🎯 Why: Interactive elements lacked visible keyboard focus rings, making keyboard navigation difficult and inaccessible.
📸 Before/After: Verified locally using Playwright (see `verification/focus-ring.png`).
♿ Accessibility: Improves visual feedback for keyboard users, meeting minimum WCAG requirements for focus visibility.

---
*PR created automatically by Jules for task [9767105670093158778](https://jules.google.com/task/9767105670093158778) started by @hadsern*