### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in SchemaScript

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,11 @@
+# Sentinel Journal
+
+## 2024-05-18 - Prevent ReDOS in term scoring
+**Vulnerability:** Regular Expression Denial of Service (ReDoS) was possible in `functions/api/ask.ts` because a regular expression was dynamically constructed directly from user input without escaping special characters. A malicious user could submit a query containing specifically crafted characters causing catastrophic backtracking or blocking execution.
+**Learning:** Even internal helper functions like `scoreDocument` should be wary of inputs passed to `RegExp` constructors.
+**Prevention:** Avoid dynamically constructing RegExps using unescaped user input. String based techniques like `indexOf` should be used for simple keyword matching instead.
+
+## 2024-05-18 - XSS vulnerability in SchemaScript.tsx
+**Vulnerability:** XSS vulnerability was present in `src/components/SchemaScript.tsx` because `JSON.stringify` does not escape HTML special characters like `<` and `>`. Injecting `JSON.stringify` data into a `<script>` tag via `dangerouslySetInnerHTML` allows for escaping the script tag if the data contains `</script>`.
+**Learning:** `JSON.stringify` does not inherently protect against XSS when its output is injected directly into HTML contexts (like script tags).
+**Prevention:** Manually escape HTML control characters like `<` and `>` when injecting `JSON.stringify` output into script tags, typically using replacements like `replace(/</g, '\\u003c')`.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -15,10 +15,10 @@ interface SchemaScriptProps {
 }
 
 export function SchemaScript({ data }: SchemaScriptProps) {
-  // JSON.stringify produces safe output for script tags — it escapes
-  // forward slashes and special characters. No HTML injection possible
-  // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // JSON.stringify by itself does not escape HTML control characters like '<' or '>'.
+  // We must manually escape '<' to prevent XSS (e.g. escaping from the script tag
+  // via </script><script>alert(1)</script>).
+  const jsonLd = JSON.stringify(data).replace(/</g, '\\u003c');
 
   return (
     <script


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `JSON.stringify` does not inherently escape HTML control characters like `<` or `>`. When the serialized output is placed directly into a `<script>` tag via `dangerouslySetInnerHTML`, a crafted payload (e.g., containing `</script><script>alert(1)</script>`) could close the `<script>` tag prematurely and execute arbitrary javascript code in the victim's browser context.
🎯 Impact: This could lead to a Cross-Site Scripting (XSS) vulnerability allowing an attacker to execute arbitrary scripts if they could manipulate the data fed to the Schema generator (although this currently only sources from internal markdown, defense-in-depth requires this fix).
🔧 Fix: Added `.replace(/</g, '\\u003c')` to manually escape `<` characters in the stringified JSON payload before injecting it into the DOM.
✅ Verification: Ensure tests pass and the `SchemaScript` renders JSON-LD correctly. All injected '<' will appear as unicode equivalents.

---
*PR created automatically by Jules for task [12077837307066326762](https://jules.google.com/task/12077837307066326762) started by @hadsern*