### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in SchemaScript

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-01 - JSON.stringify XSS in SchemaScript
+**Vulnerability:** `src/components/SchemaScript.tsx` directly injected `JSON.stringify` output into `<script dangerouslySetInnerHTML={{ __html: ... }}>` without escaping HTML control characters.
+**Learning:** `JSON.stringify` does not sanitize HTML characters like `<` and `>`. If schema data contains an embedded `</script>` tag, it can break out of the script block and execute arbitrary code (XSS). The previous comment falsely claimed it was safe.
+**Prevention:** Always manually escape `<` to `\u003c`, `>` to `\u003e`, and `&` to `\u0026` after calling `JSON.stringify` when injecting into `<script>` tags.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -2,8 +2,8 @@
  * SchemaScript — renders JSON-LD structured data in a <script> tag.
  *
  * Safety: All data comes from typed schema generators in src/lib/schema.ts.
- * No user input is ever passed to this component. The JSON.stringify output
- * is always valid JSON with no HTML special characters unescaped.
+ * No user input is ever passed to this component. However, as defense-in-depth,
+ * the JSON.stringify output is escaped to prevent XSS.
  *
  * Usage:
  *   <SchemaScript data={schemaSiteGraph()} />
@@ -15,10 +15,14 @@ interface SchemaScriptProps {
 }
 
 export function SchemaScript({ data }: SchemaScriptProps) {
-  // JSON.stringify produces safe output for script tags — it escapes
-  // forward slashes and special characters. No HTML injection possible
-  // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // JSON.stringify alone is NOT safe for script tags. It does not escape HTML
+  // control characters like < and >, meaning a string like "</script><script>alert(1)</script>"
+  // could break out of the script tag and execute arbitrary code.
+  // We must manually escape these characters to prevent XSS.
+  const jsonLd = JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
 
   return (
     <script


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `src/components/SchemaScript.tsx` injected `JSON.stringify` output into `<script>` tags without escaping HTML control characters, allowing potential XSS via unsanitized schema content (e.g., breaking out with `</script>`).
🎯 Impact: If malicious content enters the schema data (e.g., via user profiles or article metadata), it could lead to arbitrary JavaScript execution in the user's browser.
🔧 Fix: Manually escaped `<`, `>`, and `&` to their unicode equivalents (`\u003c`, `\u003e`, `\u0026`) after JSON serialization. Added defensive comments.
✅ Verification: Verified fix by running tests, validating the server output, and building the application. Added learning to Sentinel journal without committing unnecessary local artifacts.

---
*PR created automatically by Jules for task [16688107251838668199](https://jules.google.com/task/16688107251838668199) started by @hadsern*