### PR TITLE
🎨 Palette: Add keyboard focus rings for accessibility

### DIFF
--- a/src/components/ArticlesSidebar.tsx
+++ b/src/components/ArticlesSidebar.tsx
@@ -38,7 +38,7 @@ export function ArticlesSidebar({ lang, currentId, basePath, view, variant = 'de
     >
       <details open={!isMobile}>
         {isMobile && (
-          <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none">
+          <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none">
             <span className="text-xs uppercase tracking-wider text-frc-steel">{t.browse}</span>
           </summary>
         )}

--- a/src/components/BlogSidebar.tsx
+++ b/src/components/BlogSidebar.tsx
@@ -38,7 +38,7 @@ export function BlogSidebar({ lang, currentId, basePath, view, variant = 'deskto
     >
       <details open={!isMobile}>
         {isMobile && (
-          <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none">
+          <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none">
             <span className="text-xs uppercase tracking-wider text-frc-steel">{t.browse}</span>
           </summary>
         )}

--- a/src/components/BooksSidebar.tsx
+++ b/src/components/BooksSidebar.tsx
@@ -49,7 +49,7 @@ export function BooksSidebar({ lang, currentId, chapters, activeChapterSlug, bas
     >
       <details open={!isMobile}>
         {isMobile && (
-          <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none">
+          <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none">
             <span className="text-xs uppercase tracking-wider text-frc-steel">{t.browse}</span>
           </summary>
         )}

--- a/src/components/ConceptsSidebar.tsx
+++ b/src/components/ConceptsSidebar.tsx
@@ -38,7 +38,7 @@ export function ConceptsSidebar({ lang, currentId, basePath, view, variant = 'de
     >
       <details open={!isMobile}>
         {isMobile && (
-          <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none">
+          <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none">
             <span className="text-xs uppercase tracking-wider text-frc-steel">{t.browse}</span>
           </summary>
         )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -249,7 +249,7 @@ export function Header() {
             <button
               type="button"
               onClick={() => setIsMobileMenuOpen(true)}
-              className="xl:hidden text-frc-text-dim hover:text-frc-gold transition-colors w-11 h-11 inline-flex items-center justify-center -mr-2"
+              className="xl:hidden text-frc-text-dim hover:text-frc-gold transition-colors w-11 h-11 inline-flex items-center justify-center -mr-2 focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none"
               aria-label="Open menu"
               aria-expanded={isMobileMenuOpen}
               aria-controls="frc-mobile-menu"
@@ -290,7 +290,7 @@ export function Header() {
                 >
                   <button
                     type="button"
-                    className="text-xs uppercase tracking-wider px-3 py-2 text-frc-text-dim hover:text-frc-gold transition-colors inline-flex items-center gap-1"
+                    className="text-xs uppercase tracking-wider px-3 py-2 text-frc-text-dim hover:text-frc-gold transition-colors inline-flex items-center gap-1 focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none"
                     aria-haspopup="menu"
                     aria-expanded={desktopGroupOpen === group.id}
                     onClick={() => setDesktopGroupOpen((prev) => (prev === group.id ? null : group.id))}
@@ -397,7 +397,7 @@ export function Header() {
                 type="button"
                 ref={closeButtonRef}
                 onClick={() => setIsMobileMenuOpen(false)}
-                className="text-frc-text-dim hover:text-frc-gold transition-colors w-11 h-11 inline-flex items-center justify-center -mr-2"
+                className="text-frc-text-dim hover:text-frc-gold transition-colors w-11 h-11 inline-flex items-center justify-center -mr-2 focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none"
                 aria-label="Close menu"
               >
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -419,7 +419,7 @@ export function Header() {
                     className="group w-full border border-frc-blue/60 rounded-lg bg-frc-void-light/30"
                   >
                     <summary
-                      className={`px-3 py-3 cursor-pointer select-none list-none flex items-center justify-between gap-3 ${
+                      className={`px-3 py-3 cursor-pointer select-none list-none flex items-center justify-between gap-3 focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none ${
                         isRTL ? 'flex-row-reverse' : ''
                       }`}
                       aria-label={`${mobileGroupOpen[group.id] ? g.close : g.open}: ${group.label}`}

--- a/src/components/InlineToc.tsx
+++ b/src/components/InlineToc.tsx
@@ -17,7 +17,7 @@ export function InlineToc({
 
   return (
     <details className={`${hideClass} mb-6 border border-frc-blue rounded-lg ${className}`}>
-      <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none">
+      <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none">
         <span className="text-xs uppercase tracking-wider text-frc-steel">{title}</span>
       </summary>
       <nav className="px-4 pb-4">

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -51,7 +51,7 @@ export function LanguageSelector() {
     <div ref={menuRef} className="relative">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-1.5 font-mono text-[0.625rem] text-frc-steel hover:text-frc-gold tracking-wider uppercase transition-colors motion-reduce:transition-none px-2 py-2 sm:px-0 sm:py-0"
+        className="flex items-center gap-1.5 font-mono text-[0.625rem] text-frc-steel hover:text-frc-gold tracking-wider uppercase transition-colors motion-reduce:transition-none px-2 py-2 sm:px-0 sm:py-0 focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none"
         aria-label="Select language"
         aria-expanded={isOpen}
       >
@@ -86,7 +86,7 @@ export function LanguageSelector() {
             <button
               key={lang.code}
               onClick={() => switchLanguage(lang.code)}
-              className={`w-full px-3 py-2 text-xs flex items-center justify-between gap-3 transition-colors ${
+              className={`w-full px-3 py-2 text-xs flex items-center justify-between gap-3 transition-colors focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none ${
                 lang.code === currentLangCode
                   ? 'bg-frc-blue/20 text-frc-gold'
                   : 'text-frc-text-dim hover:bg-frc-blue/10 hover:text-frc-text'

--- a/src/components/PeopleSidebar.tsx
+++ b/src/components/PeopleSidebar.tsx
@@ -38,7 +38,7 @@ export function PeopleSidebar({ lang, currentId, basePath, view, variant = 'desk
     >
       <details open={!isMobile}>
         {isMobile && (
-          <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none">
+          <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none">
             <span className="text-xs uppercase tracking-wider text-frc-steel">{t.browse}</span>
           </summary>
         )}

--- a/src/components/SearchTrigger.tsx
+++ b/src/components/SearchTrigger.tsx
@@ -29,7 +29,7 @@ export function SearchTrigger({ className = '' }: SearchTriggerProps) {
     <button
       type="button"
       onClick={openSearch}
-      className={`flex items-center gap-2 text-frc-text-dim hover:text-frc-gold transition-colors ${className}`}
+      className={`flex items-center gap-2 text-frc-text-dim hover:text-frc-gold transition-colors focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none ${className}`}
       aria-label="Open search"
     >
       <svg

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -81,7 +81,7 @@ export function Sidebar({ lang, currentId, basePath, view, variant = 'desktop' }
     <aside data-sidebar className={asideClass}>
       {isMobile ? (
         <details>
-          <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none">
+          <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none">
             <span className="text-xs uppercase tracking-wider text-frc-steel">Browse library</span>
           </summary>
           {nav}
@@ -125,7 +125,7 @@ function SidebarSection({
 
   return (
     <details open={openByDefault} className="mb-4">
-      <summary className="flex items-center justify-between gap-3 text-xs uppercase tracking-wider text-frc-steel px-2 cursor-pointer select-none list-none">
+      <summary className="flex items-center justify-between gap-3 text-xs uppercase tracking-wider text-frc-steel px-2 cursor-pointer select-none list-none focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none">
         <span>{title}</span>
         <span className="text-[11px] normal-case text-frc-text-dim">{sorted.length}</span>
       </summary>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -18,7 +18,7 @@ export function ThemeToggle() {
   return (
     <button
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
-      className="text-frc-steel hover:text-frc-gold transition-colors motion-reduce:transition-none p-2 sm:p-0.5"
+      className="text-frc-steel hover:text-frc-gold transition-colors motion-reduce:transition-none p-2 sm:p-0.5 focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none"
       aria-label={`Switch to ${isDark ? 'light' : 'dark'} theme`}
       title={`Switch to ${isDark ? 'light' : 'dark'} theme`}
     >

--- a/src/components/TopicsSidebar.tsx
+++ b/src/components/TopicsSidebar.tsx
@@ -38,7 +38,7 @@ export function TopicsSidebar({ lang, currentId, basePath, view, variant = 'desk
     >
       <details open={!isMobile}>
         {isMobile && (
-          <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none">
+          <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none">
             <span className="text-xs uppercase tracking-wider text-frc-steel">{t.browse}</span>
           </summary>
         )}


### PR DESCRIPTION
💡 **What:** Added standard `focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none` classes to various unstyled interactive elements (`<button>` and `<summary>`) across header, sidebar, and layout components.
🎯 **Why:** To improve keyboard navigation usability by providing a visible, high-contrast focus indicator, ensuring the application is accessible to users relying on keyboard inputs.
📸 **Before/After:** Before, users navigating with a keyboard had no clear visual indication of which header/sidebar item was focused. After, a distinct gold ring surrounds the focused element.
♿ **Accessibility:** Enhances WCAG compliance for focus visibility (Criterion 2.4.7 Focus Visible) across the main navigation interfaces.

---
*PR created automatically by Jules for task [16796451035273562112](https://jules.google.com/task/16796451035273562112) started by @hadsern*