### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix ReDoS in search endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-25 - ReDoS Vulnerability in Search API
+**Vulnerability:** User-provided search terms were passed unescaped directly into a `RegExp` constructor in `functions/api/ask.ts`, leading to a potential Regular Expression Denial of Service (ReDoS) if crafted input was supplied.
+**Learning:** Passing unsanitized user input into regex constructors creates significant performance/stability risks.
+**Prevention:** Use string-based search functions like `indexOf` in a loop when counting occurrences, rather than dynamically generating regular expressions.

--- a/functions/api/ask.ts
+++ b/functions/api/ask.ts
@@ -54,8 +54,15 @@ function scoreDocument(doc: SearchDocument, terms: string[]): number {
     // Tag match (high weight)
     if (tagsLower.some(t => t.includes(term))) score += 5;
     // Content match (count occurrences)
-    const contentMatches = (contentLower.match(new RegExp(term, 'g')) || []).length;
-    score += Math.min(contentMatches, 5); // Cap at 5 to avoid bias toward long docs
+    let contentMatches = 0;
+    let pos = 0;
+    while (contentMatches < 5) {
+      pos = contentLower.indexOf(term, pos);
+      if (pos === -1) break;
+      contentMatches++;
+      pos += term.length;
+    }
+    score += contentMatches; // Cap at 5 to avoid bias toward long docs
   }
 
   return score;


### PR DESCRIPTION
**Severity:** CRITICAL
**Vulnerability:** Unescaped user input was passed directly into a `RegExp` constructor in `functions/api/ask.ts` during relevance scoring. This could be exploited to cause a Regular Expression Denial of Service (ReDoS).
**Impact:** Attackers could send specially crafted search queries that cause the regex engine to consume excessive CPU, degrading or completely crashing the `/api/ask` endpoint for all users.
**Fix:** Removed the dynamic `RegExp` allocation and replaced it with a safe, bounded `while` loop using `indexOf` to count up to 5 occurrences of the search term.
**Verification:** Ran `pnpm test`, `pnpm build`, and `pnpm lint`. All tests passed successfully. The changes are entirely local to the scoring algorithm.

---
*PR created automatically by Jules for task [4515559937039828386](https://jules.google.com/task/4515559937039828386) started by @hadsern*