### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS and ReDoS vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - Fix ReDoS and XSS Vulnerabilities
+**Vulnerability:** Unescaped user input passed directly into `new RegExp` in `functions/api/ask.ts` and missing HTML control character escaping when injecting `JSON.stringify` data into script tags via `dangerouslySetInnerHTML` in `src/components/SchemaScript.tsx`.
+**Learning:** `JSON.stringify` does not automatically sanitize `<` and `>` characters, leading to XSS when injected directly into script tags. Also, unescaped user input can lead to ReDoS and syntax errors when passed into `RegExp`.
+**Prevention:** Use string-based search methods like `indexOf` for user input, and manually escape `<` and `>` when injecting JSON into HTML script tags.

--- a/functions/api/ask.ts
+++ b/functions/api/ask.ts
@@ -54,8 +54,15 @@ function scoreDocument(doc: SearchDocument, terms: string[]): number {
     // Tag match (high weight)
     if (tagsLower.some(t => t.includes(term))) score += 5;
     // Content match (count occurrences)
-    const contentMatches = (contentLower.match(new RegExp(term, 'g')) || []).length;
-    score += Math.min(contentMatches, 5); // Cap at 5 to avoid bias toward long docs
+    let contentMatches = 0;
+    let pos = 0;
+    while (contentMatches < 5) {
+      const idx = contentLower.indexOf(term, pos);
+      if (idx === -1) break;
+      contentMatches++;
+      pos = idx + term.length;
+    }
+    score += contentMatches; // Cap at 5 to avoid bias toward long docs
   }
 
   return score;

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -18,7 +18,9 @@ export function SchemaScript({ data }: SchemaScriptProps) {
   // JSON.stringify produces safe output for script tags — it escapes
   // forward slashes and special characters. No HTML injection possible
   // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // We must still escape `<` and `>` specifically to prevent XSS if data
+  // contains them since JSON.stringify does not escape them.
+  const jsonLd = JSON.stringify(data).replace(/</g, '\\u003c').replace(/>/g, '\\u003e');
 
   return (
     <script


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unescaped user input passed directly into `new RegExp` in `functions/api/ask.ts` leading to potential Regular Expression Denial of Service (ReDoS) and syntax errors. Additionally, `JSON.stringify` output injected directly into script tags via `dangerouslySetInnerHTML` in `src/components/SchemaScript.tsx` lacked escaping for `<` and `>`, leading to potential Cross-Site Scripting (XSS).
🎯 **Impact:** ReDoS could result in unbounded loops and a 500 error on the search endpoint, essentially taking down search. XSS could allow attackers to execute arbitrary scripts in the context of the user's browser by injecting `</script>` payloads into structured JSON data.
🔧 **Fix:** Replaced the `RegExp` instantiation with a safe `indexOf` while-loop that explicitly caps at 5 iterations. Manually escaped `<` and `>` characters to `\u003c` and `\u003e` in the `JSON.stringify` payload before DOM insertion. Documented learnings in `.jules/sentinel.md`.
✅ **Verification:** Run `pnpm test` and `pnpm build`. Tests pass, build completes, and the vulnerabilities are remediated without loss of functionality.

---
*PR created automatically by Jules for task [4625717247793932796](https://jules.google.com/task/4625717247793932796) started by @hadsern*