### PR TITLE
🎨 Palette: Add keyboard focus rings to mode toggle buttons

### DIFF
--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -18,7 +18,7 @@ export function ModeToggleCompact() {
           key={m.id}
           type="button"
           onClick={() => setMode(m.id)}
-          className={`px-2 py-1 text-[10px] uppercase tracking-widest transition-colors ${
+          className={`px-2 py-1 text-[10px] uppercase tracking-widest transition-colors focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none ${
             mode === m.id
               ? 'bg-frc-gold text-frc-void'
               : 'text-frc-steel hover:text-frc-gold'
@@ -44,7 +44,7 @@ export function ModeSwitchButton({
 }) {
   const { setMode } = useFrcMode();
   return (
-    <button type="button" onClick={() => setMode(to)} className={className}>
+    <button type="button" onClick={() => setMode(to)} className={`focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none ${className}`}>
       {label}
     </button>
   );


### PR DESCRIPTION
💡 **What:** Added keyboard focus rings to the mode toggle buttons (`ModeToggleCompact` and `ModeSwitchButton`).
🎯 **Why:** Previously, these buttons had no visible focus state when navigating via keyboard, making it difficult for users relying on keyboard navigation to know when the elements were focused.
📸 **Before/After:** The buttons now show a 2px solid gold ring when focused via keyboard (using the `focus-visible` pseudo-class), matching the standard FRC focus pattern.
♿ **Accessibility:** This ensures the mode toggle features are fully accessible to keyboard-only users by providing clear visual focus indicators.

---
*PR created automatically by Jules for task [5642701622772751773](https://jules.google.com/task/5642701622772751773) started by @hadsern*