### PR TITLE
🎨 Palette: Add focus-visible styles for keyboard navigation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-15 - Interactive Elements Lack Keyboard Focus
+**Learning:** Found that key interactive elements in the Header and Navigation components (`SearchTrigger`, `ThemeToggle`, `LanguageSelector`, `ModeToggleCompact`) are missing the standard Tailwind `focus-visible` outline classes. This causes a confusing experience for keyboard users as they navigate through the application header, as there is no visual indicator of focus.
+**Action:** Always add standard focus-visible rings (`focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none`) to buttons and interactive links, particularly in global navigation components to ensure accessible keyboard navigation.

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -51,7 +51,7 @@ export function LanguageSelector() {
     <div ref={menuRef} className="relative">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-1.5 font-mono text-[0.625rem] text-frc-steel hover:text-frc-gold tracking-wider uppercase transition-colors motion-reduce:transition-none px-2 py-2 sm:px-0 sm:py-0"
+        className="flex items-center gap-1.5 font-mono text-[0.625rem] text-frc-steel hover:text-frc-gold tracking-wider uppercase transition-colors motion-reduce:transition-none px-2 py-2 sm:px-0 sm:py-0 focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded"
         aria-label="Select language"
         aria-expanded={isOpen}
       >
@@ -86,7 +86,7 @@ export function LanguageSelector() {
             <button
               key={lang.code}
               onClick={() => switchLanguage(lang.code)}
-              className={`w-full px-3 py-2 text-xs flex items-center justify-between gap-3 transition-colors ${
+              className={`w-full px-3 py-2 text-xs flex items-center justify-between gap-3 transition-colors focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none ${
                 lang.code === currentLangCode
                   ? 'bg-frc-blue/20 text-frc-gold'
                   : 'text-frc-text-dim hover:bg-frc-blue/10 hover:text-frc-text'

--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -18,7 +18,7 @@ export function ModeToggleCompact() {
           key={m.id}
           type="button"
           onClick={() => setMode(m.id)}
-          className={`px-2 py-1 text-[10px] uppercase tracking-widest transition-colors ${
+          className={`px-2 py-1 text-[10px] uppercase tracking-widest transition-colors focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded ${
             mode === m.id
               ? 'bg-frc-gold text-frc-void'
               : 'text-frc-steel hover:text-frc-gold'
@@ -44,7 +44,7 @@ export function ModeSwitchButton({
 }) {
   const { setMode } = useFrcMode();
   return (
-    <button type="button" onClick={() => setMode(to)} className={className}>
+    <button type="button" onClick={() => setMode(to)} className={`focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded ${className}`}>
       {label}
     </button>
   );

--- a/src/components/SearchTrigger.tsx
+++ b/src/components/SearchTrigger.tsx
@@ -29,7 +29,7 @@ export function SearchTrigger({ className = '' }: SearchTriggerProps) {
     <button
       type="button"
       onClick={openSearch}
-      className={`flex items-center gap-2 text-frc-text-dim hover:text-frc-gold transition-colors ${className}`}
+      className={`flex items-center gap-2 text-frc-text-dim hover:text-frc-gold transition-colors focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded ${className}`}
       aria-label="Open search"
     >
       <svg

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -18,7 +18,7 @@ export function ThemeToggle() {
   return (
     <button
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
-      className="text-frc-steel hover:text-frc-gold transition-colors motion-reduce:transition-none p-2 sm:p-0.5"
+      className="text-frc-steel hover:text-frc-gold transition-colors motion-reduce:transition-none p-2 sm:p-0.5 focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded"
       aria-label={`Switch to ${isDark ? 'light' : 'dark'} theme`}
       title={`Switch to ${isDark ? 'light' : 'dark'} theme`}
     >


### PR DESCRIPTION
💡 What: Added standard `focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none` styles to interactive navigation elements in the Header (`SearchTrigger`, `ThemeToggle`, `LanguageSelector`, `ModeToggleCompact`). Also added `.jules/palette.md` to document this critical accessibility learning.
🎯 Why: Keyboard users previously had no visual feedback when tabbing through key navigation items, creating a confusing and inaccessible experience.
📸 Before/After: See frontend verification screenshots showing a clear gold focus ring around the selected elements.
♿ Accessibility: Improves keyboard navigation support and focus state visibility across the global header.

---
*PR created automatically by Jules for task [4822293631769160059](https://jules.google.com/task/4822293631769160059) started by @hadsern*