### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in SchemaScript.tsx

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## YYYY-MM-DD - Unescaped JSON in Script Tags
+**Vulnerability:** Potential XSS vulnerability due to injecting raw `JSON.stringify` output into a `<script>` tag via `dangerouslySetInnerHTML`.
+**Learning:** `JSON.stringify` does not escape HTML control characters (`<`, `>`), allowing malicious data to break out of the script tag or execute as HTML if the data contains such characters.
+**Prevention:** Manually escape `<` and `>` using unicode escape sequences (`\u003c` and `\u003e`) before injecting JSON into script tags.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -15,10 +15,12 @@ interface SchemaScriptProps {
 }
 
 export function SchemaScript({ data }: SchemaScriptProps) {
-  // JSON.stringify produces safe output for script tags — it escapes
-  // forward slashes and special characters. No HTML injection possible
-  // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // JSON.stringify alone does not escape HTML control characters like < and >.
+  // To prevent XSS vulnerabilities when injecting into a script tag via
+  // dangerouslySetInnerHTML, we must manually escape them.
+  const jsonLd = JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e');
 
   return (
     <script


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Potential XSS vulnerability due to injecting raw `JSON.stringify` output into a `<script>` tag via `dangerouslySetInnerHTML`. `JSON.stringify` alone does not escape HTML control characters like `<` and `>`.
🎯 Impact: An attacker could potentially inject malicious scripts by crafting data containing unescaped HTML control characters that breaks out of the `<script>` tag or executes as HTML.
🔧 Fix: Manually escape `<` and `>` using unicode escape sequences (`\\u003c` and `\\u003e`) on the `JSON.stringify` output.
✅ Verification: Ran `pnpm test` and `pnpm build` successfully, and tested via Playwright frontend verification.

---
*PR created automatically by Jules for task [15966957984364433685](https://jules.google.com/task/15966957984364433685) started by @hadsern*