### PR TITLE
🎨 Palette: Add visual indicators to collapsible sections

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-03-16 - Custom visual indicators for collapsible sections
+**Learning:** Default browser `<details>` markers are inconsistent and difficult to style correctly, leading to poor visual feedback for expandable UI components.
+**Action:** Always implement collapsible sections by hiding default markers on `<summary>` using `list-none [&::-webkit-details-marker]:hidden`, adding standard focus-visible rings for keyboard accessibility, and using a custom SVG chevron controlled by Tailwind's `group` and `group-open` modifiers for reliable state-based rotation.

--- a/src/components/InlineToc.tsx
+++ b/src/components/InlineToc.tsx
@@ -16,9 +16,18 @@ export function InlineToc({
   const hideClass = hideAt === 'lg' ? 'lg:hidden' : hideAt === 'xl' ? 'xl:hidden' : '2xl:hidden';
 
   return (
-    <details className={`${hideClass} mb-6 border border-frc-blue rounded-lg ${className}`}>
-      <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none">
+    <details className={`group ${hideClass} mb-6 border border-frc-blue rounded-lg ${className}`}>
+      <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden flex items-center justify-between rounded focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none">
         <span className="text-xs uppercase tracking-wider text-frc-steel">{title}</span>
+        <svg
+          className="w-4 h-4 text-frc-steel transition-transform motion-reduce:transition-none group-open:rotate-180"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
       </summary>
       <nav className="px-4 pb-4">
         <ul className="space-y-1 text-sm">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -80,9 +80,18 @@ export function Sidebar({ lang, currentId, basePath, view, variant = 'desktop' }
   return (
     <aside data-sidebar className={asideClass}>
       {isMobile ? (
-        <details>
-          <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none">
+        <details className="group">
+          <summary className="px-4 py-3 text-sm text-frc-text cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden flex items-center justify-between focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none">
             <span className="text-xs uppercase tracking-wider text-frc-steel">Browse library</span>
+            <svg
+              className="w-4 h-4 text-frc-steel transition-transform motion-reduce:transition-none group-open:rotate-180"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
           </summary>
           {nav}
         </details>
@@ -124,9 +133,20 @@ function SidebarSection({
   });
 
   return (
-    <details open={openByDefault} className="mb-4">
-      <summary className="flex items-center justify-between gap-3 text-xs uppercase tracking-wider text-frc-steel px-2 cursor-pointer select-none list-none">
-        <span>{title}</span>
+    <details open={openByDefault} className="group mb-4">
+      <summary className="flex items-center justify-between gap-3 text-xs uppercase tracking-wider text-frc-steel px-2 rounded cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none">
+        <div className="flex items-center gap-1.5">
+          <svg
+            className="w-3.5 h-3.5 text-frc-steel transition-transform motion-reduce:transition-none group-open:rotate-90"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 18l6-6-6-6" />
+          </svg>
+          <span>{title}</span>
+        </div>
         <span className="text-[11px] normal-case text-frc-text-dim">{sorted.length}</span>
       </summary>
       <ul className="space-y-0.5 mt-2 max-h-64 overflow-y-auto pr-1">


### PR DESCRIPTION
💡 **What**: Replaced the default, often inconsistent browser triangle markers on `<details>` elements with custom, animated SVG chevrons in the `Sidebar` and `InlineToc` components. Also added explicit focus rings to the `<summary>` elements.
🎯 **Why**: Default browser markers provide poor visual feedback and are difficult to style consistently across browsers. Custom chevrons offer clear, reliable indicators of collapsible state, while focus rings are essential for keyboard navigation and accessibility.
📸 **Before/After**: Screenshots have been generated during frontend verification to confirm the chevron rotations and hidden default markers.
♿ **Accessibility**: Enhanced keyboard navigation by adding `focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none` to the `<summary>` elements, ensuring users navigating via keyboard have clear visual feedback of their current focus.

---
*PR created automatically by Jules for task [10373981704027954279](https://jules.google.com/task/10373981704027954279) started by @hadsern*