### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XSS vulnerability in SchemaScript

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-17 - [XSS vulnerability in SchemaScript]
+**Vulnerability:** XSS vulnerability in SchemaScript when injecting JSON.stringify into dangerouslySetInnerHTML without escaping HTML characters.
+**Learning:** JSON.stringify does NOT automatically escape HTML characters like `<` and `>`. If this is used inside dangerouslySetInnerHTML or a script tag, attackers could break out of the script tag and execute arbitrary JS by providing `</script><script>alert(1)</script>`.
+**Prevention:** Always manually escape HTML control characters after JSON.stringify when injecting into HTML.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -2,8 +2,8 @@
  * SchemaScript — renders JSON-LD structured data in a <script> tag.
  *
  * Safety: All data comes from typed schema generators in src/lib/schema.ts.
- * No user input is ever passed to this component. The JSON.stringify output
- * is always valid JSON with no HTML special characters unescaped.
+ * We manually escape HTML control characters like < and > after
+ * JSON.stringify to prevent XSS vulnerabilities.
  *
  * Usage:
  *   <SchemaScript data={schemaSiteGraph()} />
@@ -15,10 +15,10 @@ interface SchemaScriptProps {
 }
 
 export function SchemaScript({ data }: SchemaScriptProps) {
-  // JSON.stringify produces safe output for script tags — it escapes
-  // forward slashes and special characters. No HTML injection possible
-  // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // JSON.stringify does not automatically escape HTML control characters
+  // like < and >. We manually escape them to prevent XSS vulnerabilities
+  // when injecting this data into script tags via dangerouslySetInnerHTML.
+  const jsonLd = JSON.stringify(data).replace(/</g, '\\u003c').replace(/>/g, '\\u003e');
 
   return (
     <script


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: XSS vulnerability in `SchemaScript` when injecting `JSON.stringify` into `dangerouslySetInnerHTML` without escaping HTML characters. `JSON.stringify` does not automatically escape `<` and `>`. If this is used inside `dangerouslySetInnerHTML` or a script tag, attackers could break out of the script tag and execute arbitrary JS by providing `</script><script>alert(1)</script>`.
🎯 Impact: Attackers could execute arbitrary JavaScript in the victim's browser if they manage to inject malicious data into the schema objects.
🔧 Fix: We manually escape HTML control characters like `<` and `>` after `JSON.stringify` by replacing them with `\u003c` and `\u003e` respectively, preventing XSS vulnerabilities when injecting this data into script tags via `dangerouslySetInnerHTML`.
✅ Verification: Ran `pnpm test`, `pnpm lint`, and `pnpm build` to ensure the fix is correct and introduces no regressions.


---
*PR created automatically by Jules for task [16397882109537465117](https://jules.google.com/task/16397882109537465117) started by @hadsern*