### PR TITLE
🎨 Palette: Add keyboard focus rings to Mode Toggle buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Missing Focus States on Mode Toggles
+**Learning:** Found that custom toggle buttons like `ModeToggleCompact` and `ModeSwitchButton` frequently lack default browser focus indicators when styled with Tailwind, making them completely invisible to keyboard navigators.
+**Action:** When implementing custom interactive elements, always explicitly define `focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none` (or similar brand colors) to ensure keyboard accessibility without compromising mouse/touch UX.

--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -18,7 +18,7 @@ export function ModeToggleCompact() {
           key={m.id}
           type="button"
           onClick={() => setMode(m.id)}
-          className={`px-2 py-1 text-[10px] uppercase tracking-widest transition-colors ${
+          className={`px-2 py-1 text-[10px] uppercase tracking-widest transition-colors focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded-sm ${
             mode === m.id
               ? 'bg-frc-gold text-frc-void'
               : 'text-frc-steel hover:text-frc-gold'
@@ -44,7 +44,7 @@ export function ModeSwitchButton({
 }) {
   const { setMode } = useFrcMode();
   return (
-    <button type="button" onClick={() => setMode(to)} className={className}>
+    <button type="button" onClick={() => setMode(to)} className={`${className} focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded-sm`}>
       {label}
     </button>
   );


### PR DESCRIPTION
💡 **What:** Added explicitly defined `focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none` Tailwind utility classes to the custom interactive `<button>` elements inside the `ModeToggleCompact` and `ModeSwitchButton` components.
🎯 **Why:** The mode toggle buttons lacked default browser focus indicators due to their custom styling, making it impossible for keyboard-only or screen reader users to track focus and navigate the page structure properly. This UX enhancement restores keyboard visibility to a highly used interactive element.
📸 **Before/After:** Before this change, tabbing through the mode toggles produced zero visual feedback. Now, active elements display a crisp gold focus ring.
♿ **Accessibility:** This directly resolves a fundamental web accessibility and compliance issue by explicitly defining high-contrast focus indicators for interactive buttons (WCAG 2.1 SC 2.4.7 Focus Visible).

---
*PR created automatically by Jules for task [11136842881869310054](https://jules.google.com/task/11136842881869310054) started by @hadsern*