### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix ReDoS and unhandled exception in search scoring

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-16 - Prevent ReDoS and unhandled SyntaxError in scoreDocument
+**Vulnerability:** The application was dynamically passing unsanitized user query terms (`term`) directly into `new RegExp(term, 'g')` in `functions/api/ask.ts`. This exposed the `scoreDocument` function to Regular Expression Denial of Service (ReDoS) and unhandled crashes if a user searched for invalid regex characters (like `[`).
+**Learning:** Using `new RegExp` with unsanitized user input is risky and can lead to server crashes or resource exhaustion, even if the matches are later capped.
+**Prevention:** Avoid dynamically generating regular expressions with user input. When possible, prefer pure string-based search methods like `indexOf` within a `while` loop, particularly for simple term-counting logic.

--- a/functions/api/ask.ts
+++ b/functions/api/ask.ts
@@ -54,8 +54,13 @@ function scoreDocument(doc: SearchDocument, terms: string[]): number {
     // Tag match (high weight)
     if (tagsLower.some(t => t.includes(term))) score += 5;
     // Content match (count occurrences)
-    const contentMatches = (contentLower.match(new RegExp(term, 'g')) || []).length;
-    score += Math.min(contentMatches, 5); // Cap at 5 to avoid bias toward long docs
+    let contentMatches = 0;
+    let pos = contentLower.indexOf(term);
+    while (pos !== -1 && contentMatches < 5) {
+      contentMatches++;
+      pos = contentLower.indexOf(term, pos + term.length);
+    }
+    score += contentMatches; // Cap at 5 to avoid bias toward long docs, enforced in the while loop
   }
 
   return score;


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `/api/ask` endpoint dynamically constructed regular expressions directly from user queries (`new RegExp(term, 'g')`). If a user entered invalid regex characters (e.g., `[` or `*`), it would throw an unhandled `SyntaxError` and crash the execution for that query. Furthermore, complex or malicious queries could potentially trigger ReDoS.
🎯 Impact: Search functionality could be reliably broken by simple typos containing regex control characters.
🔧 Fix: Replaced the dynamic `RegExp` with a simple `while` loop utilizing `indexOf` to count occurrences of a term within the document content up to a maximum of 5, providing the same behavior with `O(1)` performance and complete resilience against any string input.
✅ Verification: Tested locally via `pnpm test` and `pnpm build`. Validated search works identically. Added a Sentinel journal entry.

---
*PR created automatically by Jules for task [10988603273388917835](https://jules.google.com/task/10988603273388917835) started by @hadsern*