### PR TITLE
🎨 Palette: Add focus states to interactive nav/utility buttons

### DIFF
--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -18,7 +18,7 @@ export function ModeToggleCompact() {
           key={m.id}
           type="button"
           onClick={() => setMode(m.id)}
-          className={`px-2 py-1 text-[10px] uppercase tracking-widest transition-colors ${
+          className={`px-2 py-1 text-[10px] uppercase tracking-widest focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded transition-colors ${
             mode === m.id
               ? 'bg-frc-gold text-frc-void'
               : 'text-frc-steel hover:text-frc-gold'
@@ -44,7 +44,7 @@ export function ModeSwitchButton({
 }) {
   const { setMode } = useFrcMode();
   return (
-    <button type="button" onClick={() => setMode(to)} className={className}>
+    <button type="button" onClick={() => setMode(to)} className={`${className} focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded`}>
       {label}
     </button>
   );

--- a/src/components/ReadingMode.tsx
+++ b/src/components/ReadingMode.tsx
@@ -31,7 +31,7 @@ export function ReadingMode() {
   return (
     <button
       onClick={toggle}
-      className={`fixed bottom-6 right-6 z-50 w-10 h-10 flex items-center justify-center border transition-all ${
+      className={`fixed bottom-6 right-6 z-50 w-10 h-10 flex items-center justify-center border focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none transition-all ${
         active
           ? 'bg-frc-gold border-frc-gold text-frc-void'
           : 'bg-frc-void border-frc-blue text-frc-text-dim hover:text-frc-gold hover:border-frc-gold'

--- a/src/components/SearchTrigger.tsx
+++ b/src/components/SearchTrigger.tsx
@@ -29,7 +29,7 @@ export function SearchTrigger({ className = '' }: SearchTriggerProps) {
     <button
       type="button"
       onClick={openSearch}
-      className={`flex items-center gap-2 text-frc-text-dim hover:text-frc-gold transition-colors ${className}`}
+      className={`flex items-center gap-2 text-frc-text-dim hover:text-frc-gold focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded transition-colors ${className}`}
       aria-label="Open search"
     >
       <svg

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -18,7 +18,7 @@ export function ThemeToggle() {
   return (
     <button
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
-      className="text-frc-steel hover:text-frc-gold transition-colors motion-reduce:transition-none p-2 sm:p-0.5"
+      className="text-frc-steel hover:text-frc-gold focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded transition-colors motion-reduce:transition-none p-2 sm:p-0.5"
       aria-label={`Switch to ${isDark ? 'light' : 'dark'} theme`}
       title={`Switch to ${isDark ? 'light' : 'dark'} theme`}
     >


### PR DESCRIPTION
💡 What: Added `focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none` standard focus styles to `ModeToggle`, `ReadingMode`, `SearchTrigger`, and `ThemeToggle` components.
🎯 Why: Keyboard users lacked clear visual feedback when tabbing to these buttons, which degraded the navigation experience.
📸 Before/After: Verified visual output using Playwright screens. Now, keyboard tabbing correctly highlights active navigational elements using a gold focus ring.
♿ Accessibility: Ensures WCAG focus visibility standards are met natively with standard Tailwind styling.

---
*PR created automatically by Jules for task [16805978913405602751](https://jules.google.com/task/16805978913405602751) started by @hadsern*