### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS via Unescaped RegExp in Search

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-20 - Fix DoS via Unescaped RegExp in Search
+**Vulnerability:** Unescaped user input passed directly to `RegExp` constructor in `functions/api/ask.ts` allows DoS via unhandled SyntaxError (e.g., query with `[`) or ReDoS.
+**Learning:** Never pass unescaped user input to `new RegExp`. In serverless environments like Cloudflare Workers, regex compilation errors or ReDoS can exhaust CPU limits and cause crashes.
+**Prevention:** Use pure string-based search methods like `indexOf` in a loop for simple text matching instead of dynamic `RegExp` construction.

--- a/functions/api/ask.ts
+++ b/functions/api/ask.ts
@@ -54,8 +54,13 @@ function scoreDocument(doc: SearchDocument, terms: string[]): number {
     // Tag match (high weight)
     if (tagsLower.some(t => t.includes(term))) score += 5;
     // Content match (count occurrences)
-    const contentMatches = (contentLower.match(new RegExp(term, 'g')) || []).length;
-    score += Math.min(contentMatches, 5); // Cap at 5 to avoid bias toward long docs
+    let contentMatches = 0;
+    let pos = contentLower.indexOf(term);
+    while (pos !== -1 && contentMatches < 5) {
+      contentMatches++;
+      pos = contentLower.indexOf(term, pos + term.length);
+    }
+    score += contentMatches; // Cap at 5 to avoid bias toward long docs
   }
 
   return score;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Unescaped user input passed directly to `RegExp` constructor in `functions/api/ask.ts` allows DoS via unhandled SyntaxError (e.g., query with `[`) or ReDoS.
🎯 Impact: An attacker can easily crash the endpoint by providing an invalid regular expression or by passing a string crafted for catastrophic backtracking (ReDoS).
🔧 Fix: Replaced dynamic `RegExp` construction with a pure string-based `indexOf` loop. It accurately preserves the original logic (finding non-overlapping matches and capping the score addition at 5) while entirely eliminating the regex vulnerability.
✅ Verification: Ran `pnpm build` and `pnpm test` successfully. Verified that no additional dependencies or artifacts were added to the commit.

---
*PR created automatically by Jules for task [2029776708598245090](https://jules.google.com/task/2029776708598245090) started by @hadsern*