### PR TITLE
🎨 Palette: Improve keyboard focus visibility for navigation actions

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -51,7 +51,7 @@ export function LanguageSelector() {
     <div ref={menuRef} className="relative">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-1.5 font-mono text-[0.625rem] text-frc-steel hover:text-frc-gold tracking-wider uppercase transition-colors motion-reduce:transition-none px-2 py-2 sm:px-0 sm:py-0"
+        className="flex items-center gap-1.5 font-mono text-[0.625rem] text-frc-steel hover:text-frc-gold tracking-wider uppercase transition-colors motion-reduce:transition-none px-2 py-2 sm:px-0 sm:py-0 focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none"
         aria-label="Select language"
         aria-expanded={isOpen}
       >
@@ -86,7 +86,7 @@ export function LanguageSelector() {
             <button
               key={lang.code}
               onClick={() => switchLanguage(lang.code)}
-              className={`w-full px-3 py-2 text-xs flex items-center justify-between gap-3 transition-colors ${
+              className={`w-full px-3 py-2 text-xs flex items-center justify-between gap-3 transition-colors focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none ${
                 lang.code === currentLangCode
                   ? 'bg-frc-blue/20 text-frc-gold'
                   : 'text-frc-text-dim hover:bg-frc-blue/10 hover:text-frc-text'

--- a/src/components/SearchTrigger.tsx
+++ b/src/components/SearchTrigger.tsx
@@ -29,7 +29,7 @@ export function SearchTrigger({ className = '' }: SearchTriggerProps) {
     <button
       type="button"
       onClick={openSearch}
-      className={`flex items-center gap-2 text-frc-text-dim hover:text-frc-gold transition-colors ${className}`}
+      className={`flex items-center gap-2 text-frc-text-dim hover:text-frc-gold transition-colors focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none ${className}`}
       aria-label="Open search"
     >
       <svg

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -18,7 +18,7 @@ export function ThemeToggle() {
   return (
     <button
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
-      className="text-frc-steel hover:text-frc-gold transition-colors motion-reduce:transition-none p-2 sm:p-0.5"
+      className="text-frc-steel hover:text-frc-gold transition-colors motion-reduce:transition-none p-2 sm:p-0.5 focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none"
       aria-label={`Switch to ${isDark ? 'light' : 'dark'} theme`}
       title={`Switch to ${isDark ? 'light' : 'dark'} theme`}
     >


### PR DESCRIPTION
💡 **What:** Added standard `focus-visible` CSS classes (`focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none`) to the Theme Toggle, Search Trigger, and Language Selector buttons.
🎯 **Why:** To ensure that keyboard users have clear, highly visible focus indicators when navigating the primary header actions, improving overall accessibility and usability.
📸 **Before/After:** No visible changes for mouse users. Keyboard users will now see a bright gold ring (the repository's standard `frc-gold` focus ring) around the buttons when using `Tab` to navigate.
♿ **Accessibility:** Fixes WCAG 2.1 Success Criterion 2.4.7 (Focus Visible) for these three interactive navigation buttons, making keyboard navigation on the header robust and intuitive.

**Verification:**
* Verified via Playwright screenshots that the standard `frc-gold` focus ring renders correctly upon keyboard focus.
* Verified `pnpm test` passes.
* Verified `pnpm build` completes successfully.

---
*PR created automatically by Jules for task [14276318152986797260](https://jules.google.com/task/14276318152986797260) started by @hadsern*