### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in SchemaScript.tsx

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-21 - JSON-LD Script Tag XSS
+**Vulnerability:** JSON-LD script tags via `dangerouslySetInnerHTML` were vulnerable to XSS due to unescaped HTML characters (`<` and `>`) in `JSON.stringify`.
+**Learning:** `JSON.stringify` does not automatically escape HTML control characters, allowing attackers to break out of `<script>` tags if input contains `</script>`.
+**Prevention:** Manually escape `<` as `\u003c` and `>` as `\u003e` (using `replace(/</g, '\\u003c').replace(/>/g, '\\u003e')`) before injection.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -18,7 +18,8 @@ export function SchemaScript({ data }: SchemaScriptProps) {
   // JSON.stringify produces safe output for script tags — it escapes
   // forward slashes and special characters. No HTML injection possible
   // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // Sentinel: Manually escape < and > to prevent XSS.
+  const jsonLd = JSON.stringify(data).replace(/</g, '\\u003c').replace(/>/g, '\\u003e');
 
   return (
     <script


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** JSON-LD script tags via `dangerouslySetInnerHTML` were vulnerable to XSS due to unescaped HTML characters (`<` and `>`) in `JSON.stringify`. `JSON.stringify` does not automatically escape HTML control characters, allowing attackers to break out of `<script>` tags if the schema input contained a sequence like `</script>`.
🎯 **Impact:** An attacker could execute arbitrary JavaScript within the context of the user's browser, potentially leading to data theft, session hijacking, or malicious actions on behalf of the user.
🔧 **Fix:** Manually escape `<` to `\u003c` and `>` to `\u003e` in the `JSON.stringify` output before injecting it into the DOM.
✅ **Verification:** Ran `pnpm test`, `pnpm build`, and verified changes in `src/components/SchemaScript.tsx` correctly execute the escape replacements. Recorded learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [11018690962748706128](https://jules.google.com/task/11018690962748706128) started by @hadsern*