### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix error message leakage in API response

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-14 - Prevent Error Message Leakage in API Responses
+**Vulnerability:** The API endpoint `functions/api/ask.ts` was returning internal error messages (`error.message`) in its 500 responses to the client. This could potentially expose internal application logic or configuration details to an attacker.
+**Learning:** In Cloudflare Pages Functions, or any public-facing API, we must avoid leaking internal error details to the client.
+**Prevention:** Only return generic error messages to the client. Log the detailed error message server-side for debugging purposes.

--- a/functions/api/ask.ts
+++ b/functions/api/ask.ts
@@ -211,7 +211,6 @@ Provide a helpful answer based on the context above. Cite sources using [1], [2]
     console.error('Ask API error:', error);
     return new Response(JSON.stringify({
       error: 'Failed to process question',
-      details: error instanceof Error ? error.message : 'Unknown error',
     }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The API endpoint `functions/api/ask.ts` was returning internal error messages (`error.message`) in its 500 responses to the client. This could potentially expose internal application logic or configuration details to an attacker.
🎯 Impact: Internal application logic or configuration details could be exposed to an attacker.
🔧 Fix: Removed the internal `error.message` from the 500 response.
✅ Verification: Ran `pnpm test` and `pnpm build` successfully, verified the response no longer includes the `details` field.

---
*PR created automatically by Jules for task [11251762292669900081](https://jules.google.com/task/11251762292669900081) started by @hadsern*