### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in JSON-LD injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-26 - Prevent XSS in JSON-LD Script Tags
+**Vulnerability:** XSS vulnerability in `SchemaScript.tsx` where `JSON.stringify` data was injected into `<script>` tags using `dangerouslySetInnerHTML` without escaping HTML control characters.
+**Learning:** `JSON.stringify` does not automatically escape `<` or `>` characters. If user-controlled data containing `</script><script>alert(1)</script>` is passed, it breaks out of the JSON-LD script block and executes arbitrary JavaScript.
+**Prevention:** Always manually escape HTML control characters like `<` (as `\u003c`) and `>` (as `\u003e`) when injecting stringified JSON into HTML using `dangerouslySetInnerHTML`.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -15,10 +15,10 @@ interface SchemaScriptProps {
 }
 
 export function SchemaScript({ data }: SchemaScriptProps) {
-  // JSON.stringify produces safe output for script tags — it escapes
-  // forward slashes and special characters. No HTML injection possible
-  // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // JSON.stringify does NOT automatically escape < or > characters.
+  // We must manually escape them to prevent XSS via </script> injection
+  // when injecting into dangerouslySetInnerHTML.
+  const jsonLd = JSON.stringify(data).replace(/</g, '\\u003c').replace(/>/g, '\\u003e');
 
   return (
     <script


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `JSON.stringify` does not automatically escape HTML control characters like `<` and `>`. Injecting stringified JSON directly into `<script>` tags using `dangerouslySetInnerHTML` allows for Cross-Site Scripting (XSS) if user input contains `</script><script>alert(1)</script>`.
🎯 Impact: An attacker could execute arbitrary JavaScript by breaking out of the JSON-LD script block.
🔧 Fix: Manually escape `<` and `>` characters using `replace` after `JSON.stringify`.
✅ Verification: Ran `pnpm test` and `pnpm build` successfully.

---
*PR created automatically by Jules for task [15682950018079944102](https://jules.google.com/task/15682950018079944102) started by @hadsern*