### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and focus rings to buttons

### DIFF
--- a/src/components/DownloadMarkdown.tsx
+++ b/src/components/DownloadMarkdown.tsx
@@ -47,7 +47,7 @@ export function DownloadMarkdown({ id, title, content, lang = 'en' }: DownloadMa
   return (
     <button
       onClick={handleDownload}
-      className="inline-flex items-center gap-2 text-xs font-mono px-3 py-1.5 border border-frc-blue rounded-md text-frc-text-dim hover:text-frc-gold hover:border-frc-gold transition-colors"
+      className="inline-flex items-center gap-2 text-xs font-mono px-3 py-1.5 border border-frc-blue rounded-md text-frc-text-dim hover:text-frc-gold hover:border-frc-gold transition-colors focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none"
       title={t.download}
     >
       <svg

--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -18,7 +18,7 @@ export function ModeToggleCompact() {
           key={m.id}
           type="button"
           onClick={() => setMode(m.id)}
-          className={`px-2 py-1 text-[10px] uppercase tracking-widest transition-colors ${
+          className={`px-2 py-1 text-[10px] uppercase tracking-widest transition-colors focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none ${
             mode === m.id
               ? 'bg-frc-gold text-frc-void'
               : 'text-frc-steel hover:text-frc-gold'
@@ -44,7 +44,7 @@ export function ModeSwitchButton({
 }) {
   const { setMode } = useFrcMode();
   return (
-    <button type="button" onClick={() => setMode(to)} className={className}>
+    <button type="button" onClick={() => setMode(to)} className={`focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none ${className}`}>
       {label}
     </button>
   );

--- a/src/components/TextSharePopover.tsx
+++ b/src/components/TextSharePopover.tsx
@@ -88,6 +88,8 @@ export function TextSharePopover() {
         onClick={copyText}
         onMouseDown={(e) => e.preventDefault()}
         title={copied ? 'Copied!' : 'Copy text'}
+        aria-label="Copy text"
+        className="focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none"
       >
         {copied ? (
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -106,6 +108,8 @@ export function TextSharePopover() {
         onClick={shareTwitter}
         onMouseDown={(e) => e.preventDefault()}
         title="Share on X"
+        aria-label="Share on X"
+        className="focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none"
       >
         <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor">
           <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
@@ -117,6 +121,8 @@ export function TextSharePopover() {
         onClick={shareLink}
         onMouseDown={(e) => e.preventDefault()}
         title="Copy page link"
+        aria-label="Copy page link"
+        className="focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none"
       >
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
           <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />


### PR DESCRIPTION
💡 **What:** Added missing `aria-label` attributes to icon-only share buttons (Copy, X/Twitter, Link) in `TextSharePopover.tsx`. Added `focus-visible` ring utility classes to buttons in `TextSharePopover.tsx`, `ModeToggle.tsx`, and `DownloadMarkdown.tsx`.
🎯 **Why:** To improve accessibility by providing context to screen readers for icon-only buttons, and to enhance keyboard navigation usability by ensuring a visible, standardized focus state is presented when tabbing through interactive elements.
♿ **Accessibility:** Improved screen reader context (WCAG 4.1.2 Name, Role, Value) and keyboard focus visibility (WCAG 2.4.7 Focus Visible).

---
*PR created automatically by Jules for task [6236039032654660810](https://jules.google.com/task/6236039032654660810) started by @hadsern*