### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in SchemaScript

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - JSON.stringify XSS in Script Tags
+**Vulnerability:** XSS vulnerability via unescaped HTML control characters in JSON stringified data injected into script tags using `dangerouslySetInnerHTML`.
+**Learning:** `JSON.stringify` does not automatically escape HTML characters like `<` and `>`, allowing malicious payload execution if injected into a `<script>` tag.
+**Prevention:** Always manually escape `<` and `>` (e.g., `.replace(/</g, '\u003c').replace(/>/g, '\u003e')`) when using `JSON.stringify` inside `<script>` tags.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -15,10 +15,10 @@ interface SchemaScriptProps {
 }
 
 export function SchemaScript({ data }: SchemaScriptProps) {
-  // JSON.stringify produces safe output for script tags — it escapes
-  // forward slashes and special characters. No HTML injection possible
-  // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // JSON.stringify does NOT automatically escape HTML control characters like < and >,
+  // so we must manually escape them to prevent XSS vulnerabilities when injecting
+  // into script tags via dangerouslySetInnerHTML.
+  const jsonLd = JSON.stringify(data).replace(/</g, '\\u003c').replace(/>/g, '\\u003e');
 
   return (
     <script


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Cross-Site Scripting (XSS) via unescaped HTML control characters in JSON serialized data injected into a `<script>` tag.
🎯 **Impact:** If an attacker were able to manipulate a field that gets passed to `SchemaScript` (e.g. via content markdown frontmatter that influences a schema), they could include a `</script>` tag to break out of the JSON context and execute arbitrary JavaScript using a trailing `<script>` payload.
🔧 **Fix:** Appended `.replace(/</g, '\\u003c').replace(/>/g, '\\u003e')` to the `JSON.stringify` output. This correctly escapes the characters into their unicode equivalents, which are valid inside a JSON string but cannot be interpreted as HTML markup by the browser. 
✅ **Verification:** Verified that `src/components/SchemaScript.tsx` properly applies the escaping regex. Ran `pnpm test`, `pnpm lint`, and `pnpm build` successfully to verify functionality. Documented the learning in `.jules/sentinel.md`. All build artifacts were reverted before commit to keep the PR clean.

---
*PR created automatically by Jules for task [2204778942706717875](https://jules.google.com/task/2204778942706717875) started by @hadsern*