### PR TITLE
🎨 Palette: Improve keyboard focus a11y for icon buttons

### DIFF
--- a/src/components/ReadingMode.tsx
+++ b/src/components/ReadingMode.tsx
@@ -31,7 +31,7 @@ export function ReadingMode() {
   return (
     <button
       onClick={toggle}
-      className={`fixed bottom-6 right-6 z-50 w-10 h-10 flex items-center justify-center border transition-all ${
+      className={`fixed bottom-6 right-6 z-50 w-10 h-10 flex items-center justify-center border transition-all focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded-sm ${
         active
           ? 'bg-frc-gold border-frc-gold text-frc-void'
           : 'bg-frc-void border-frc-blue text-frc-text-dim hover:text-frc-gold hover:border-frc-gold'
@@ -40,11 +40,11 @@ export function ReadingMode() {
       title={active ? 'Exit reading mode (Esc)' : 'Enter reading mode'}
     >
       {active ? (
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
           <path d="M18 6L6 18M6 6l12 12" />
         </svg>
       ) : (
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
           <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
           <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
         </svg>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -18,17 +18,17 @@ export function ThemeToggle() {
   return (
     <button
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
-      className="text-frc-steel hover:text-frc-gold transition-colors motion-reduce:transition-none p-2 sm:p-0.5"
+      className="text-frc-steel hover:text-frc-gold transition-colors motion-reduce:transition-none p-2 sm:p-0.5 focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded-sm"
       aria-label={`Switch to ${isDark ? 'light' : 'dark'} theme`}
       title={`Switch to ${isDark ? 'light' : 'dark'} theme`}
     >
       {isDark ? (
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
           <circle cx="12" cy="12" r="5" />
           <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
         </svg>
       ) : (
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
           <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
         </svg>
       )}


### PR DESCRIPTION
💡 What: Added visual keyboard focus rings (`focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded-sm`) and `aria-hidden="true"` to inner decorative SVGs in `ThemeToggle` and `ReadingMode` icon-only buttons.
🎯 Why: Without visual focus rings, keyboard navigators and visually impaired users cannot see which interactive element has focus. Additionally, `aria-hidden="true"` prevents screen readers from redundantly announcing the decorative SVG.
📸 Before/After: Visual focus state added (verified via Playwright tests).
♿ Accessibility: Better keyboard focus visualization and cleaner screen reader announcements.

---
*PR created automatically by Jules for task [14533685973888072191](https://jules.google.com/task/14533685973888072191) started by @hadsern*