### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XSS vulnerability in SchemaScript

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-28 - Fix XSS Vulnerability in JSON-LD Script Tag
+**Vulnerability:** XSS via `JSON.stringify` inside `<script>` tags using `dangerouslySetInnerHTML`. The code incorrectly assumed `JSON.stringify` escaped HTML special characters (`<`, `>`).
+**Learning:** `JSON.stringify` does NOT escape HTML characters. Attackers can inject `</script>` tags into JSON fields (like titles) to break out of the script context and execute arbitrary JS.
+**Prevention:** Always escape `<` (`\u003c`), `>` (`\u003e`), and `&` (`\u0026`) after `JSON.stringify` when injecting into script tags, even if the data originates from internal schemas.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -18,7 +18,12 @@ export function SchemaScript({ data }: SchemaScriptProps) {
   // JSON.stringify produces safe output for script tags — it escapes
   // forward slashes and special characters. No HTML injection possible
   // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // Note: JSON.stringify does NOT automatically escape <, >, or & which
+  // can lead to XSS if user data contains </script> tags.
+  const jsonLd = JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
 
   return (
     <script


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: XSS via `JSON.stringify` inside `<script>` tags using `dangerouslySetInnerHTML`. The code incorrectly assumed `JSON.stringify` escaped HTML special characters (`<`, `>`).
🎯 Impact: Attackers could inject `</script>` tags into JSON fields (like article titles) to break out of the script context and execute arbitrary JS, potentially leading to session hijacking or unauthorized actions.
🔧 Fix: Added explicit escaping for `<` (`\u003c`), `>` (`\u003e`), and `&` (`\u0026`) on the output of `JSON.stringify`.
✅ Verification: Ran `pnpm test` and `pnpm build`. Validated that the file correctly applies the Unicode replacement. Added documentation into `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [11416965022347924801](https://jules.google.com/task/11416965022347924801) started by @hadsern*