### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in JSON-LD output

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Title]
+**Vulnerability:** XSS in SchemaScript.tsx via JSON.stringify
+**Learning:** `JSON.stringify` does not escape HTML control characters like `<`, `>`, and `&`. Injecting `JSON.stringify` directly into script tags using `dangerouslySetInnerHTML` is an XSS vulnerability if any part of the JSON object can be manipulated by an attacker, even if the data comes from 'trusted' schema generators. The comment in `SchemaScript.tsx` explicitly states "JSON.stringify produces safe output for script tags — it escapes forward slashes and special characters. No HTML injection possible", which is factually incorrect.
+**Prevention:** Always manually escape HTML control characters (e.g. `<`, `>`, `&`) when embedding JSON into script tags. Next.js `JSON.stringify` output needs manual sanitization before using it with `dangerouslySetInnerHTML`.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -15,10 +15,14 @@ interface SchemaScriptProps {
 }
 
 export function SchemaScript({ data }: SchemaScriptProps) {
-  // JSON.stringify produces safe output for script tags — it escapes
-  // forward slashes and special characters. No HTML injection possible
-  // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // JSON.stringify by itself does NOT escape HTML characters like <, >, or &.
+  // If user-controlled data ever enters the JSON, it could break out of the
+  // script tag and cause XSS. We manually replace dangerous characters with
+  // their unicode equivalents to ensure safety.
+  const jsonLd = JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
 
   return (
     <script


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `JSON.stringify` does not escape HTML control characters like `<`, `>`, and `&`. Injecting `JSON.stringify` directly into script tags using `dangerouslySetInnerHTML` is an XSS vulnerability if any part of the JSON object can be manipulated.
🎯 Impact: Attackers could inject arbitrary JavaScript to execute in the user's browser, potentially leading to unauthorized actions and data theft.
🔧 Fix: Replaced `<, >, and &` with their unicode escapes (`\u003c`, `\u003e`, `\u0026`) after serialization in `src/components/SchemaScript.tsx`. Added Sentinel learning record.
✅ Verification: Ran `pnpm test`, `pnpm build`, and `pnpm lint`. Confirmed the fix manually using `node -e`.

---
*PR created automatically by Jules for task [14473311550357361730](https://jules.google.com/task/14473311550357361730) started by @hadsern*