### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in SchemaScript

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-10-25 - XSS Vulnerability in JSON.stringify
+**Vulnerability:** XSS vulnerability in `src/components/SchemaScript.tsx` due to injecting `JSON.stringify` output directly into a `<script>` tag via `dangerouslySetInnerHTML`.
+**Learning:** `JSON.stringify` alone is not safe for generating script tag content because it doesn't escape HTML control characters like `<` and `>`, allowing attackers to close the tag early.
+**Prevention:** Always manually escape `<`, `>`, and `&` to Unicode sequences (`\u003c`, `\u003e`, `\u0026`) when injecting JSON into HTML script tags.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -15,10 +15,12 @@ interface SchemaScriptProps {
 }
 
 export function SchemaScript({ data }: SchemaScriptProps) {
-  // JSON.stringify produces safe output for script tags — it escapes
-  // forward slashes and special characters. No HTML injection possible
-  // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // JSON.stringify does NOT automatically escape HTML characters.
+  // We must manually escape <, >, and & to prevent XSS.
+  const jsonLd = JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
 
   return (
     <script


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `JSON.stringify` does not automatically escape HTML control characters. This allows an attacker to inject `</script>` into the structured data, prematurely terminating the script tag and executing arbitrary JavaScript.
🎯 Impact: High - Cross-Site Scripting (XSS). Allows malicious code execution on users visiting the site.
🔧 Fix: Manually escaped `<`, `>`, and `&` to their Unicode hex equivalents (`\u003c`, `\u003e`, `\u0026`) on the output of `JSON.stringify`.
✅ Verification: Tested against `pnpm test` and `pnpm build`. Code review confirmed it safely neutralizes the vulnerability without introducing regressions to valid JSON. Documented the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [6037420290795289373](https://jules.google.com/task/6037420290795289373) started by @hadsern*