### PR TITLE
🎨 Palette: Add aria-label to OracleChat input

### DIFF
--- a/src/components/OracleChat.tsx
+++ b/src/components/OracleChat.tsx
@@ -235,6 +235,7 @@ export function OracleChat({ lang }: OracleChatProps) {
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder={t.placeholder}
+            aria-label={t.placeholder}
             disabled={isLoading}
             className="flex-1 bg-transparent border border-frc-blue/30 rounded px-3 py-2 text-sm text-frc-text placeholder-frc-text-dim focus:outline-none focus:border-frc-gold/50"
           />


### PR DESCRIPTION
💡 What: Added an `aria-label` attribute to the input field in the `OracleChat` component.
🎯 Why: The input field lacked a dedicated `<label>` element, making it inaccessible to screen reader users who could not infer its purpose. The `aria-label` mirrors the placeholder text to provide clear context.
📸 Before/After: Visual appearance remains exactly the same.
♿ Accessibility: Improves form interaction for users relying on assistive technologies by ensuring the search/chat input is properly identified.

---
*PR created automatically by Jules for task [14614369039523393981](https://jules.google.com/task/14614369039523393981) started by @hadsern*