### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in JSON-LD injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-31 - JSON.stringify XSS Risk in Script Tags
+**Vulnerability:** Unescaped HTML control characters in JSON string injected via dangerouslySetInnerHTML.
+**Learning:** JSON.stringify does not escape characters like `<`, `>`, and `&` which allows attackers to terminate script tags and execute malicious scripts.
+**Prevention:** Always manually escape `<`, `>`, and `&` (e.g. using `replace`) when passing stringified JSON into dangerouslySetInnerHTML for script tags.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -18,7 +18,10 @@ export function SchemaScript({ data }: SchemaScriptProps) {
   // JSON.stringify produces safe output for script tags — it escapes
   // forward slashes and special characters. No HTML injection possible
   // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  const jsonLd = JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
 
   return (
     <script


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Unescaped HTML control characters in JSON string injected via `dangerouslySetInnerHTML`.
🎯 **Impact**: JSON stringified outputs containing malicious script tags (e.g. `</script>`) could terminate the script tag and execute arbitrary JS, leading to XSS if any data somehow contained user input.
🔧 **Fix**: Escaped `<`, `>`, and `&` to their unicode equivalents (`\u003c`, `\u003e`, `\u0026`) in `SchemaScript.tsx`.
✅ **Verification**: Tests (`pnpm test`) and build (`pnpm build`) run perfectly. Ensured `dangerouslySetInnerHTML` injects safe output.

---
*PR created automatically by Jules for task [6257676018787963007](https://jules.google.com/task/6257676018787963007) started by @hadsern*