### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS Vulnerability in SchemaScript

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-01 - Fix XSS Vulnerability in SchemaScript
+**Vulnerability:** JSON.stringify output was directly injected into a <script> tag via dangerouslySetInnerHTML without escaping HTML control characters (<, >, &).
+**Learning:** React dangerouslySetInnerHTML with JSON.stringify does not automatically sanitize HTML control characters, leading to XSS if user input ever makes its way into the schema.
+**Prevention:** Always manually escape HTML control characters (<, >, &) when serializing JSON for injection into script tags, e.g. using .replace(/</g, '\u003c').replace(/>/g, '\u003e').replace(/&/g, '\u0026');.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -15,10 +15,11 @@ interface SchemaScriptProps {
 }
 
 export function SchemaScript({ data }: SchemaScriptProps) {
-  // JSON.stringify produces safe output for script tags — it escapes
-  // forward slashes and special characters. No HTML injection possible
-  // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // Safely stringify JSON-LD, escaping HTML special characters to prevent XSS.
+  const jsonLd = JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
 
   return (
     <script


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** `JSON.stringify` output was directly injected into a `<script>` tag via `dangerouslySetInnerHTML` in `SchemaScript.tsx` without escaping HTML control characters (`<`, `>`, `&`). The previous developer assumed `JSON.stringify` alone was safe from HTML injection.
🎯 **Impact:** If user input (like search terms or profile data) ever makes its way into the schema generators (e.g., in a title or description), an attacker could inject arbitrary HTML/JavaScript by including characters like `</script><script>alert(1)</script>`.
🔧 **Fix:** Chained `.replace()` methods to safely escape `<`, `>`, and `&` to their unicode equivalents when serializing the JSON-LD payload, effectively neutralizing the XSS vector while preserving valid JSON.
✅ **Verification:**
1. Ran `pnpm test` (all 24 tests pass, confirming valid JSON schema).
2. Ran `pnpm build` (compiles cleanly).
3. The change is strictly limited to `src/components/SchemaScript.tsx` and the journal entry in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [8487649778124309498](https://jules.google.com/task/8487649778124309498) started by @hadsern*