### PR TITLE
🎨 Palette: Add keyboard focus state to ThemeToggle

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -18,7 +18,7 @@ export function ThemeToggle() {
   return (
     <button
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
-      className="text-frc-steel hover:text-frc-gold transition-colors motion-reduce:transition-none p-2 sm:p-0.5"
+      className="text-frc-steel hover:text-frc-gold focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none transition-colors motion-reduce:transition-none p-2 sm:p-0.5"
       aria-label={`Switch to ${isDark ? 'light' : 'dark'} theme`}
       title={`Switch to ${isDark ? 'light' : 'dark'} theme`}
     >


### PR DESCRIPTION
💡 What: Added standard `focus-visible` ring styling to the ThemeToggle button.
🎯 Why: Keyboard users previously had no clear visual indication when the dark mode toggle was focused.
♿ Accessibility: Improves keyboard navigation support and visibility.

---
*PR created automatically by Jules for task [7514854120971888820](https://jules.google.com/task/7514854120971888820) started by @hadsern*