### PR TITLE
🛡️ Sentinel: [HIGH] Fix ReDoS vulnerability in search scoring

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - Prevent ReDoS in Search Scoring
+**Vulnerability:** Passing unescaped user input directly into a `RegExp` constructor in the Ask API search function caused a Regular Expression Denial of Service (ReDoS) vulnerability and the potential for unhandled `SyntaxError` exceptions that crash the process.
+**Learning:** Always treat user-provided search terms as unsafe for regex compilation unless properly escaped.
+**Prevention:** Use pure string search methods like `indexOf` in a loop when counting occurrences, especially since the match count was already artificially capped at 5.

--- a/functions/api/ask.ts
+++ b/functions/api/ask.ts
@@ -54,8 +54,13 @@ function scoreDocument(doc: SearchDocument, terms: string[]): number {
     // Tag match (high weight)
     if (tagsLower.some(t => t.includes(term))) score += 5;
     // Content match (count occurrences)
-    const contentMatches = (contentLower.match(new RegExp(term, 'g')) || []).length;
-    score += Math.min(contentMatches, 5); // Cap at 5 to avoid bias toward long docs
+    let contentMatches = 0;
+    let pos = 0;
+    while (contentMatches < 5 && (pos = contentLower.indexOf(term, pos)) !== -1) {
+      contentMatches++;
+      pos += term.length;
+    }
+    score += contentMatches;
   }
 
   return score;


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Passing unescaped user input directly into a `RegExp` constructor in the Ask API search function (`functions/api/ask.ts`) caused a Regular Expression Denial of Service (ReDoS) vulnerability and the potential for unhandled `SyntaxError` exceptions that crash the process.
🎯 **Impact:** An attacker could craft malicious search queries containing specific regular expression meta-characters to either exploit the regex engine's backtracking mechanisms (causing high CPU usage/Denial of Service) or cause a process crash by forcing a `SyntaxError` on invalid regex strings.
🔧 **Fix:** Replaced the unsafe `new RegExp(term, 'g')` with a pure, safe string search loop using `String.prototype.indexOf`. The loop counts string occurrences securely and limits matches to 5, preventing both ReDoS and infinite loops.
✅ **Verification:** Ran `pnpm test` and verified that the fix handles search logic safely without regression. The build step (`pnpm build`) and indexing successfully passed. Created a `.jules/sentinel.md` entry.

---
*PR created automatically by Jules for task [16797356828580343466](https://jules.google.com/task/16797356828580343466) started by @hadsern*