### PR TITLE
🎨 Palette: Improve keyboard focus accessibility on header buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-03 - Interactive Element Keyboard Accessibility
+**Learning:** The application lacked consistent keyboard focus visibility on generic icon buttons in the header components (ThemeToggle, SearchTrigger, LanguageSelector). Additionally, embedded SVG icons were still potentially visible to screen readers despite having no semantic meaning.
+**Action:** Applied standard Tailwind utility classes (`focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded`) to all utility buttons to guarantee keyboard navigation cues without disrupting mouse styling. Applied `aria-hidden="true"` to inner `<svg>` children to prevent redundant or confusing screen reader announcements.

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -51,7 +51,7 @@ export function LanguageSelector() {
     <div ref={menuRef} className="relative">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-1.5 font-mono text-[0.625rem] text-frc-steel hover:text-frc-gold tracking-wider uppercase transition-colors motion-reduce:transition-none px-2 py-2 sm:px-0 sm:py-0"
+        className="flex items-center gap-1.5 font-mono text-[0.625rem] text-frc-steel hover:text-frc-gold focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded tracking-wider uppercase transition-colors motion-reduce:transition-none px-2 py-2 sm:px-0 sm:py-0"
         aria-label="Select language"
         aria-expanded={isOpen}
       >
@@ -61,6 +61,7 @@ export function LanguageSelector() {
           viewBox="0 0 24 24"
           stroke="currentColor"
           strokeWidth={1.5}
+          aria-hidden="true"
         >
           <path
             strokeLinecap="round"
@@ -75,6 +76,7 @@ export function LanguageSelector() {
           viewBox="0 0 24 24"
           stroke="currentColor"
           strokeWidth={2}
+          aria-hidden="true"
         >
           <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
         </svg>
@@ -86,7 +88,7 @@ export function LanguageSelector() {
             <button
               key={lang.code}
               onClick={() => switchLanguage(lang.code)}
-              className={`w-full px-3 py-2 text-xs flex items-center justify-between gap-3 transition-colors ${
+              className={`w-full px-3 py-2 text-xs flex items-center justify-between gap-3 focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none transition-colors ${
                 lang.code === currentLangCode
                   ? 'bg-frc-blue/20 text-frc-gold'
                   : 'text-frc-text-dim hover:bg-frc-blue/10 hover:text-frc-text'

--- a/src/components/SearchTrigger.tsx
+++ b/src/components/SearchTrigger.tsx
@@ -29,7 +29,7 @@ export function SearchTrigger({ className = '' }: SearchTriggerProps) {
     <button
       type="button"
       onClick={openSearch}
-      className={`flex items-center gap-2 text-frc-text-dim hover:text-frc-gold transition-colors ${className}`}
+      className={`flex items-center gap-2 text-frc-text-dim hover:text-frc-gold focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded transition-colors ${className}`}
       aria-label="Open search"
     >
       <svg
@@ -37,6 +37,7 @@ export function SearchTrigger({ className = '' }: SearchTriggerProps) {
         fill="none"
         stroke="currentColor"
         viewBox="0 0 24 24"
+        aria-hidden="true"
       >
         <path
           strokeLinecap="round"

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -18,17 +18,17 @@ export function ThemeToggle() {
   return (
     <button
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
-      className="text-frc-steel hover:text-frc-gold transition-colors motion-reduce:transition-none p-2 sm:p-0.5"
+      className="text-frc-steel hover:text-frc-gold focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded transition-colors motion-reduce:transition-none p-2 sm:p-0.5"
       aria-label={`Switch to ${isDark ? 'light' : 'dark'} theme`}
       title={`Switch to ${isDark ? 'light' : 'dark'} theme`}
     >
       {isDark ? (
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
           <circle cx="12" cy="12" r="5" />
           <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
         </svg>
       ) : (
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
           <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
         </svg>
       )}


### PR DESCRIPTION
💡 **What:** Added visible focus rings for keyboard navigation to the utility buttons in the header (Search, Theme, Language) and marked their inner decorative SVG icons as hidden from screen readers.
🎯 **Why:** To improve accessibility for users navigating via keyboard (so they can clearly see which interactive element is focused) and screen reader users (by removing non-semantic, confusing SVG node announcements).
♿ **Accessibility:**
- Added standard `focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none` classes to buttons.
- Applied `aria-hidden="true"` to all inner decorative `<svg>` nodes.

---
*PR created automatically by Jules for task [9963412204620083851](https://jules.google.com/task/9963412204620083851) started by @hadsern*