### PR TITLE
🛡️ Sentinel: [HIGH] Fix ReDoS and SyntaxError in search API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-05 - ReDoS in Ask API Search Scoring
+**Vulnerability:** User-provided search terms were passed unescaped directly into a `new RegExp(term, 'g')` constructor in `functions/api/ask.ts`.
+**Learning:** Passing unescaped strings to `RegExp` can lead to Regular Expression Denial of Service (ReDoS) or cause unhandled `SyntaxError` crashes when users input special regex characters.
+**Prevention:** Use pure string-based search methods like `indexOf` in a loop when counting substring occurrences of user input, instead of dynamically allocating regular expressions.

--- a/functions/api/ask.ts
+++ b/functions/api/ask.ts
@@ -53,9 +53,14 @@ function scoreDocument(doc: SearchDocument, terms: string[]): number {
     if (abstractLower.includes(term)) score += 5;
     // Tag match (high weight)
     if (tagsLower.some(t => t.includes(term))) score += 5;
-    // Content match (count occurrences)
-    const contentMatches = (contentLower.match(new RegExp(term, 'g')) || []).length;
-    score += Math.min(contentMatches, 5); // Cap at 5 to avoid bias toward long docs
+    // Content match (count occurrences using indexOf to prevent ReDoS/SyntaxError)
+    let contentMatches = 0;
+    let pos = 0;
+    while (contentMatches < 5 && (pos = contentLower.indexOf(term, pos)) !== -1) {
+      contentMatches++;
+      pos += term.length;
+    }
+    score += contentMatches;
   }
 
   return score;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: User-provided search queries in `/api/ask` were directly passed to the `RegExp` constructor without escaping. This exposes the Cloudflare Page Function to Regular Expression Denial of Service (ReDoS) and unhandled `SyntaxError` crashes when malicious or invalid regex strings are searched.
🎯 Impact: Attackers could send carefully crafted payloads causing the server-side Node environment to hang (high CPU usage/timeout due to ReDoS) or crash (500 errors via SyntaxError).
🔧 Fix: Replaced `new RegExp` dynamic evaluation with a pure string-based `indexOf` loop to safely count up to 5 occurrences of the search term within the content document.
✅ Verification: Ran `pnpm test` and `pnpm build` to confirm no regressions. Added a journal entry to `.jules/sentinel.md` outlining the vulnerability and prevention strategy.

---
*PR created automatically by Jules for task [12539889822216709293](https://jules.google.com/task/12539889822216709293) started by @hadsern*