### PR TITLE
🎨 Palette: Add focus-visible rings to global navigation buttons

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -51,7 +51,7 @@ export function LanguageSelector() {
     <div ref={menuRef} className="relative">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-1.5 font-mono text-[0.625rem] text-frc-steel hover:text-frc-gold tracking-wider uppercase transition-colors motion-reduce:transition-none px-2 py-2 sm:px-0 sm:py-0"
+        className="flex items-center gap-1.5 font-mono text-[0.625rem] text-frc-steel hover:text-frc-gold tracking-wider uppercase transition-colors motion-reduce:transition-none px-2 py-2 sm:px-0 sm:py-0 focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded"
         aria-label="Select language"
         aria-expanded={isOpen}
       >
@@ -86,7 +86,7 @@ export function LanguageSelector() {
             <button
               key={lang.code}
               onClick={() => switchLanguage(lang.code)}
-              className={`w-full px-3 py-2 text-xs flex items-center justify-between gap-3 transition-colors ${
+              className={`w-full px-3 py-2 text-xs flex items-center justify-between gap-3 transition-colors focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none ${
                 lang.code === currentLangCode
                   ? 'bg-frc-blue/20 text-frc-gold'
                   : 'text-frc-text-dim hover:bg-frc-blue/10 hover:text-frc-text'

--- a/src/components/SearchTrigger.tsx
+++ b/src/components/SearchTrigger.tsx
@@ -29,7 +29,7 @@ export function SearchTrigger({ className = '' }: SearchTriggerProps) {
     <button
       type="button"
       onClick={openSearch}
-      className={`flex items-center gap-2 text-frc-text-dim hover:text-frc-gold transition-colors ${className}`}
+      className={`flex items-center gap-2 text-frc-text-dim hover:text-frc-gold transition-colors rounded focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none ${className}`}
       aria-label="Open search"
     >
       <svg

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -18,7 +18,7 @@ export function ThemeToggle() {
   return (
     <button
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
-      className="text-frc-steel hover:text-frc-gold transition-colors motion-reduce:transition-none p-2 sm:p-0.5"
+      className="text-frc-steel hover:text-frc-gold transition-colors motion-reduce:transition-none p-2 sm:p-0.5 rounded focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none"
       aria-label={`Switch to ${isDark ? 'light' : 'dark'} theme`}
       title={`Switch to ${isDark ? 'light' : 'dark'} theme`}
     >


### PR DESCRIPTION
### 💡 What
Added `focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded` to `LanguageSelector`, `SearchTrigger`, and `ThemeToggle` interactive buttons in the global navigation header.

### 🎯 Why
These buttons previously lacked clear, explicit visual indicators when focused via keyboard navigation, making it difficult for users relying on keyboard tabbing to identify their current position on the page.

### ♿ Accessibility
This micro-UX improvement ensures full keyboard accessibility for the primary interactive header elements. When focused via keyboard, they now render a clear, accessible focus ring using the design system's existing gold design token (`frc-gold`).

### 📸 Before/After
- **Before:** Buttons receive invisible native focus out-of-the-box making keyboard navigation invisible.
- **After:** Tabbing to the search, language, or theme toggle buttons activates a clean, accessible gold focus ring.

---
*PR created automatically by Jules for task [15763565016151461868](https://jules.google.com/task/15763565016151461868) started by @hadsern*