### PR TITLE
🎨 Palette: Add aria-hidden to decorative SVGs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Missing aria-hidden on decorative SVGs
+**Learning:** Decorative and inner SVGs within `button`s or `a` elements often lack `aria-hidden="true"`, causing screen readers to incorrectly read out SVG code or present redundant elements if the parent has an `aria-label`.
+**Action:** Adding `aria-hidden="true"` to inner `<svg>` elements is a very simple < 50 line UX fix.

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -56,6 +56,7 @@ export function LanguageSelector() {
         aria-expanded={isOpen}
       >
         <svg
+          aria-hidden="true"
           className="w-3.5 h-3.5"
           fill="none"
           viewBox="0 0 24 24"
@@ -70,6 +71,7 @@ export function LanguageSelector() {
         </svg>
         <span>{currentLang.code}</span>
         <svg
+          aria-hidden="true"
           className={`w-2.5 h-2.5 transition-transform motion-reduce:transition-none ${isOpen ? 'rotate-180' : ''}`}
           fill="none"
           viewBox="0 0 24 24"

--- a/src/components/ReadingMode.tsx
+++ b/src/components/ReadingMode.tsx
@@ -40,11 +40,11 @@ export function ReadingMode() {
       title={active ? 'Exit reading mode (Esc)' : 'Enter reading mode'}
     >
       {active ? (
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
           <path d="M18 6L6 18M6 6l12 12" />
         </svg>
       ) : (
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
           <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
           <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
         </svg>

--- a/src/components/SearchTrigger.tsx
+++ b/src/components/SearchTrigger.tsx
@@ -33,6 +33,7 @@ export function SearchTrigger({ className = '' }: SearchTriggerProps) {
       aria-label="Open search"
     >
       <svg
+        aria-hidden="true"
         className="w-4 h-4"
         fill="none"
         stroke="currentColor"

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -23,12 +23,12 @@ export function ThemeToggle() {
       title={`Switch to ${isDark ? 'light' : 'dark'} theme`}
     >
       {isDark ? (
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
           <circle cx="12" cy="12" r="5" />
           <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
         </svg>
       ) : (
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
           <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
         </svg>
       )}


### PR DESCRIPTION
💡 **What:** Added `aria-hidden="true"` to decorative inner `<svg>` tags within `button`s in `LanguageSelector`, `ReadingMode`, `SearchTrigger`, and `ThemeToggle`. Included a `palette.md` journal entry with learning.

🎯 **Why:** To improve accessibility for screen reader users by preventing the announcement of raw, redundant, or confusing SVG path elements, allowing them to rely strictly on the parent element's `aria-label`.

📸 **Before/After:** No visual changes.

♿ **Accessibility:** Prevents redundant or confusing screen reader announcements for decorative icons inside interactive elements that already specify `aria-label`.

---
*PR created automatically by Jules for task [5337212856526150592](https://jules.google.com/task/5337212856526150592) started by @hadsern*