### PR TITLE
🎨 Palette: Add aria-hidden to icon-only button SVGs

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -56,6 +56,7 @@ export function LanguageSelector() {
         aria-expanded={isOpen}
       >
         <svg
+          aria-hidden="true"
           className="w-3.5 h-3.5"
           fill="none"
           viewBox="0 0 24 24"
@@ -70,6 +71,7 @@ export function LanguageSelector() {
         </svg>
         <span>{currentLang.code}</span>
         <svg
+          aria-hidden="true"
           className={`w-2.5 h-2.5 transition-transform motion-reduce:transition-none ${isOpen ? 'rotate-180' : ''}`}
           fill="none"
           viewBox="0 0 24 24"

--- a/src/components/SearchTrigger.tsx
+++ b/src/components/SearchTrigger.tsx
@@ -33,6 +33,7 @@ export function SearchTrigger({ className = '' }: SearchTriggerProps) {
       aria-label="Open search"
     >
       <svg
+        aria-hidden="true"
         className="w-4 h-4"
         fill="none"
         stroke="currentColor"

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -23,12 +23,12 @@ export function ThemeToggle() {
       title={`Switch to ${isDark ? 'light' : 'dark'} theme`}
     >
       {isDark ? (
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
           <circle cx="12" cy="12" r="5" />
           <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
         </svg>
       ) : (
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
           <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
         </svg>
       )}


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to the decorative `<svg>` elements inside buttons across `LanguageSelector`, `SearchTrigger`, and `ThemeToggle` components.
🎯 Why: Prevents screen readers from redundantly announcing the inner `<svg>` elements when the parent `<button>` already has descriptive visible text or an explicit `aria-label`.
📸 Before/After: Visual presentation is identical (invisible accessibility improvement).
♿ Accessibility: Improves screen reader experience by hiding decorative icons and focusing entirely on the button's intended label.

---
*PR created automatically by Jules for task [4067815529065894174](https://jules.google.com/task/4067815529065894174) started by @hadsern*