### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in SchemaScript

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Escape HTML control characters in JSON.stringify for script tags
+**Vulnerability:** Potential XSS when injecting `JSON.stringify` output directly into `<script>` tags via `dangerouslySetInnerHTML`.
+**Learning:** `JSON.stringify` does not escape HTML control characters like `<` and `>`. If the data contains `</script>`, it can break out of the script tag.
+**Prevention:** Always manually escape HTML control characters using `.replace(/</g, '\\u003c').replace(/>/g, '\\u003e').replace(/&/g, '\\u0026')` after stringifying data intended for script tags.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -2,8 +2,8 @@
  * SchemaScript — renders JSON-LD structured data in a <script> tag.
  *
  * Safety: All data comes from typed schema generators in src/lib/schema.ts.
- * No user input is ever passed to this component. The JSON.stringify output
- * is always valid JSON with no HTML special characters unescaped.
+ * No user input is ever passed to this component. We manually escape HTML
+ * control characters in the JSON output to prevent XSS vulnerabilities.
  *
  * Usage:
  *   <SchemaScript data={schemaSiteGraph()} />
@@ -15,10 +15,13 @@ interface SchemaScriptProps {
 }
 
 export function SchemaScript({ data }: SchemaScriptProps) {
-  // JSON.stringify produces safe output for script tags — it escapes
-  // forward slashes and special characters. No HTML injection possible
-  // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // JSON.stringify does not automatically escape HTML control characters.
+  // We must manually escape <, >, and & to prevent XSS vulnerabilities
+  // when injecting JSON into a <script> tag via dangerouslySetInnerHTML.
+  const jsonLd = JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
 
   return (
     <script


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Potential XSS in `SchemaScript.tsx` because `JSON.stringify` output was passed directly to `<script dangerouslySetInnerHTML>`. By default, `JSON.stringify` does not escape HTML control characters like `<` and `>`.
🎯 **Impact:** If `data` contained strings like `</script><script>alert(1)</script>`, it could break out of the JSON-LD script block and execute malicious code.
🔧 **Fix:** Added `.replace(/</g, '\\u003c').replace(/>/g, '\\u003e').replace(/&/g, '\\u0026')` to manually escape HTML control characters after stringifying. (Used double backslashes to ensure the literal escape sequence is output).
✅ **Verification:** Ran `pnpm build` and `pnpm test` successfully. Verified the patch escapes correctly and results in valid JSON. Added learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [16493234878282896701](https://jules.google.com/task/16493234878282896701) started by @hadsern*