### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in SchemaScript JSON-LD injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-10 - JSON.stringify XSS in SchemaScript
+**Vulnerability:** JSON-LD script tags via dangerouslySetInnerHTML using unescaped JSON.stringify data.
+**Learning:** JSON.stringify does not escape HTML control characters like <, >, or &. The code comment incorrectly assumed it was safe from HTML injection.
+**Prevention:** Always manually escape < to \u003c, > to \u003e, and & to \u0026 after JSON.stringify when placing its output into script tags.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -15,10 +15,13 @@ interface SchemaScriptProps {
 }
 
 export function SchemaScript({ data }: SchemaScriptProps) {
-  // JSON.stringify produces safe output for script tags — it escapes
-  // forward slashes and special characters. No HTML injection possible
-  // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // JSON.stringify does NOT automatically escape HTML control characters.
+  // We must manually escape <, >, and & to prevent XSS vulnerabilities
+  // when injecting this into a script tag via dangerouslySetInnerHTML.
+  const jsonLd = JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
 
   return (
     <script


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Cross-Site Scripting (XSS) via `dangerouslySetInnerHTML` combined with unescaped `JSON.stringify` data. The JSON data could potentially be crafted to break out of the script tag context and execute arbitrary JS code.
🎯 Impact: An attacker could potentially inject malicious scripts into the page if any untrusted data finds its way into the schema structures.
🔧 Fix: Added `.replace(/</g, '\\u003c').replace(/>/g, '\\u003e').replace(/&/g, '\\u0026')` to manually escape HTML control characters in the JSON output.
✅ Verification: Ran `pnpm test` and `pnpm build` to verify standard JSON output validation. Checked `.jules/sentinel.md` learning entry. Cleaned up untracked/modified build artifacts.

---
*PR created automatically by Jules for task [6732524255690952](https://jules.google.com/task/6732524255690952) started by @hadsern*