### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-11 - Error Details Information Disclosure
+**Vulnerability:** The API endpoint `/api/ask` (in `functions/api/ask.ts`) leaks the raw error message (`error.message`) to the client when a 500 error occurs.
+**Learning:** This could expose internal implementation details or stack traces to external users.
+**Prevention:** Catch errors and respond with generic error messages like "Failed to process question", logging the detailed error server-side instead.

--- a/functions/api/ask.ts
+++ b/functions/api/ask.ts
@@ -211,7 +211,7 @@ Provide a helpful answer based on the context above. Cite sources using [1], [2]
     console.error('Ask API error:', error);
     return new Response(JSON.stringify({
       error: 'Failed to process question',
-      details: error instanceof Error ? error.message : 'Unknown error',
+      // Intentionally not exposing error details
     }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `/api/ask` endpoint was returning raw `error.message` strings directly to the client when a 500 server error occurred, which could leak internal path structures, stack traces, or other sensitive execution context details.
🎯 Impact: An attacker could glean internal details about the application's implementation, making it easier to craft targeted attacks or identify further vulnerabilities.
🔧 Fix: Replaced the `details: error.message` field in the JSON response with a comment (`// Intentionally not exposing error details`) and ensured errors are only logged server-side via `console.error`.
✅ Verification: Tested via `pnpm test` and `pnpm build`. Validated that the endpoint correctly returns a generic 'Failed to process question' response on error.

---
*PR created automatically by Jules for task [4811988719105191627](https://jules.google.com/task/4811988719105191627) started by @hadsern*