### PR TITLE
🎨 Palette: [UX improvement] Enhance accessibility of text share popover and mode toggle buttons

### DIFF
--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -18,7 +18,7 @@ export function ModeToggleCompact() {
           key={m.id}
           type="button"
           onClick={() => setMode(m.id)}
-          className={`px-2 py-1 text-[10px] uppercase tracking-widest transition-colors ${
+          className={`px-2 py-1 text-[10px] uppercase tracking-widest transition-colors focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded ${
             mode === m.id
               ? 'bg-frc-gold text-frc-void'
               : 'text-frc-steel hover:text-frc-gold'
@@ -44,7 +44,7 @@ export function ModeSwitchButton({
 }) {
   const { setMode } = useFrcMode();
   return (
-    <button type="button" onClick={() => setMode(to)} className={className}>
+    <button type="button" onClick={() => setMode(to)} className={`focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded ${className}`}>
       {label}
     </button>
   );

--- a/src/components/TextSharePopover.tsx
+++ b/src/components/TextSharePopover.tsx
@@ -88,13 +88,15 @@ export function TextSharePopover() {
         onClick={copyText}
         onMouseDown={(e) => e.preventDefault()}
         title={copied ? 'Copied!' : 'Copy text'}
+        aria-label={copied ? 'Copied!' : 'Copy text'}
+        className="focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded"
       >
         {copied ? (
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
             <path d="M20 6L9 17l-5-5" />
           </svg>
         ) : (
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
             <rect x="9" y="9" width="13" height="13" rx="2" />
             <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
           </svg>
@@ -106,8 +108,10 @@ export function TextSharePopover() {
         onClick={shareTwitter}
         onMouseDown={(e) => e.preventDefault()}
         title="Share on X"
+        aria-label="Share on X"
+        className="focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded"
       >
-        <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor">
+        <svg aria-hidden="true" width="13" height="13" viewBox="0 0 24 24" fill="currentColor">
           <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
         </svg>
       </button>
@@ -117,8 +121,10 @@ export function TextSharePopover() {
         onClick={shareLink}
         onMouseDown={(e) => e.preventDefault()}
         title="Copy page link"
+        aria-label="Copy page link"
+        className="focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded"
       >
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
           <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
           <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
         </svg>


### PR DESCRIPTION
**💡 What:** Added missing `aria-label` attributes to icon-only buttons, hid decorative SVGs from screen readers using `aria-hidden="true"`, and introduced visible focus rings for keyboard navigation on the text share popover and mode toggle buttons.

**🎯 Why:** To improve accessibility for screen-reader users who couldn't identify the purpose of the icon-only buttons, and to aid keyboard-only users who lacked visual feedback when navigating through these interactive elements.

**📸 Before/After:** The visual changes are only apparent when using a keyboard to navigate. Before, the focused elements had no outline. Now, they have a clear gold ring to indicate focus. Screen readers will now announce "Copy text", "Share on X", and "Copy page link" respectively instead of just "button".

**♿ Accessibility:** Added ARIA labels to icon-only buttons, `aria-hidden="true"` to SVGs, and `focus-visible` styles for better keyboard navigation.

---
*PR created automatically by Jules for task [11375895879535515440](https://jules.google.com/task/11375895879535515440) started by @hadsern*