### PR TITLE
⚡ Bolt: Pre-index KnowledgeGraph data for O(1) searches

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-12 - Pre-index Large Datasets for Client-Side Filtering
+**Learning:** In components dealing with large datasets like graphs, repeatedly converting string properties to lowercase and scanning arrays during high-frequency user interactions (like keystrokes) wastes significant CPU cycles and creates latency.
+**Action:** When implementing client-side search/filtering over large object arrays, use `useMemo` to construct an index combining a `Map` (for O(1) exact lookups) and a pre-lowercased string array (for partial O(N) filtering) to minimize redundant string conversions and iterations.

--- a/src/components/KnowledgeGraph.tsx
+++ b/src/components/KnowledgeGraph.tsx
@@ -101,13 +101,33 @@ export function KnowledgeGraph({ data, lang }: KnowledgeGraphProps) {
     return { nodes, links };
   }, [data.nodes, data.links, enabledTypes]);
 
+  // BOLT OPTIMIZATION: Pre-index search data to avoid O(N) repetitive lowercase conversions on every keystroke
+  const searchIndex = useMemo(() => {
+    const exactMap = new Map<string, GraphNode>();
+    const searchableNodes: { node: GraphNode; idLower: string; titleLower: string }[] = [];
+
+    for (const node of filtered.nodes) {
+      const idLower = node.id.toLowerCase();
+      const titleLower = (node.title || '').toLowerCase();
+      exactMap.set(idLower, node);
+      searchableNodes.push({ node, idLower, titleLower });
+    }
+
+    return { exactMap, searchableNodes };
+  }, [filtered.nodes]);
+
   const suggestions = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (q.length < 2) return [];
-    return filtered.nodes
-      .filter((n) => n.id.toLowerCase().includes(q) || (n.title || '').toLowerCase().includes(q))
-      .slice(0, 8);
-  }, [filtered.nodes, query]);
+    const results: GraphNode[] = [];
+    for (const { node, idLower, titleLower } of searchIndex.searchableNodes) {
+      if (idLower.includes(q) || titleLower.includes(q)) {
+        results.push(node);
+        if (results.length >= 8) break;
+      }
+    }
+    return results;
+  }, [searchIndex, query]);
 
   useEffect(() => {
     focusIdRef.current = focusId;
@@ -307,7 +327,8 @@ export function KnowledgeGraph({ data, lang }: KnowledgeGraphProps) {
     }
 
     const focusLower = focus.toLowerCase();
-    const focusNode = filtered.nodes.find((n) => n.id.toLowerCase() === focusLower) || null;
+    // BOLT OPTIMIZATION: Use pre-indexed Map for O(1) exact lookups instead of O(N) array search
+    const focusNode = searchIndex.exactMap.get(focusLower) || null;
     if (!focusNode) return;
     const neighbors = sel.adjacency[focusNode.id] || new Set<string>();
 
@@ -355,11 +376,18 @@ export function KnowledgeGraph({ data, lang }: KnowledgeGraphProps) {
               if (e.key !== 'Enter') return;
               const q = query.trim().toLowerCase();
               if (!q) return;
-              const match =
-                filtered.nodes.find((n) => n.id.toLowerCase() === q) ||
-                filtered.nodes.find((n) => n.id.toLowerCase().includes(q) || (n.title || '').toLowerCase().includes(q)) ||
-                null;
-              if (match) setFocusId(match.id);
+              // BOLT OPTIMIZATION: Fast path O(1) map lookup, fallback to O(N) pre-lowercased scan
+              const exactMatch = searchIndex.exactMap.get(q);
+              if (exactMatch) {
+                setFocusId(exactMatch.id);
+                return;
+              }
+              const partialMatch = searchIndex.searchableNodes.find(
+                (sn) => sn.idLower.includes(q) || sn.titleLower.includes(q)
+              );
+              if (partialMatch) {
+                setFocusId(partialMatch.node.id);
+              }
             }}
             className="w-full bg-frc-void border border-frc-blue/60 rounded px-2 py-1 text-frc-text-dim focus:outline-none focus:border-frc-gold"
             placeholder="Search id or title…"


### PR DESCRIPTION
### 💡 What
Replaced O(N) array scanning and repetitive lowercase string conversions in the `KnowledgeGraph` component with a pre-indexed data structure using `useMemo`. We now construct an O(1) `exactMap` for direct node resolution, and a `searchableNodes` array with pre-computed lowercase fields to vastly accelerate partial search matches on every keystroke. 

### 🎯 Why
During high-frequency user interactions (like typing in the filter box), constantly scanning thousands of graph nodes and converting their `id` and `title` fields to lowercase on every `onKeyDown` and `useMemo` evaluation cycle wastes significant CPU cycles, causing latency and potentially dropping frames in the simulation or input updates.

### 📊 Impact
Reduces the time complexity of exact ID lookups from O(N) to O(1).
Reduces the overhead of partial matches from O(N) * string allocation to an optimized O(N) scan using pre-allocated strings.
Changes the suggestions array generator from scanning the whole node array to early-exiting after 8 results, speeding up generation time.

### 🔬 Measurement
Run `pnpm test` and `pnpm build` to verify nothing was broken. In the UI, searching inside the KnowledgeGraph will exhibit fewer delays and dropped frames on rapid keystrokes.

---
*PR created automatically by Jules for task [11594944099461901583](https://jules.google.com/task/11594944099461901583) started by @hadsern*