### PR TITLE
🛡️ Sentinel: [HIGH] Fix ReDoS / SyntaxError vulnerability in search endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-12 - Fix ReDoS/SyntaxError in search terms
+**Vulnerability:** Constructing `RegExp` objects directly from user search queries without escaping special characters.
+**Learning:** This leads to unhandled `SyntaxError` crashes when queries contain invalid regex syntax (e.g., `[`) and introduces potential ReDoS vulnerabilities.
+**Prevention:** Use safe string search methods like `indexOf` in a loop to count substring occurrences, or properly escape user input before passing it to the `RegExp` constructor. Ensure to check `term.length > 0` when using `indexOf` loops to prevent infinite loops.

--- a/functions/api/ask.ts
+++ b/functions/api/ask.ts
@@ -54,7 +54,16 @@ function scoreDocument(doc: SearchDocument, terms: string[]): number {
     // Tag match (high weight)
     if (tagsLower.some(t => t.includes(term))) score += 5;
     // Content match (count occurrences)
-    const contentMatches = (contentLower.match(new RegExp(term, 'g')) || []).length;
+    // 🛡️ SECURITY: Use safe string search (indexOf) instead of new RegExp(term, 'g')
+    // to prevent SyntaxError crashes from unescaped inputs (e.g. '[') and mitigate ReDoS.
+    let contentMatches = 0;
+    if (term.length > 0) {
+      let pos = contentLower.indexOf(term);
+      while (pos !== -1) {
+        contentMatches++;
+        pos = contentLower.indexOf(term, pos + term.length);
+      }
+    }
     score += Math.min(contentMatches, 5); // Cap at 5 to avoid bias toward long docs
   }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `scoreDocument` function in `functions/api/ask.ts` constructs a `RegExp` directly from unescaped user queries (`term`). This allows malicious users to crash the worker with a `SyntaxError` (e.g. by passing `[`) and opens the door for ReDoS attacks.
🎯 Impact: Denial of service via uncaught exceptions causing worker crash, and potential excessive CPU consumption (ReDoS).
🔧 Fix: Replaced `contentLower.match(new RegExp(term, 'g'))` with a safe, string-based `indexOf` loop that handles all characters securely. Also included a length check to prevent infinite loops on empty strings.
✅ Verification: `pnpm test` and `pnpm build` pass. Attempting to search for `[` will no longer crash the process.

---
*PR created automatically by Jules for task [2537321656599556956](https://jules.google.com/task/2537321656599556956) started by @hadsern*