### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in SchemaScript

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-28 - Unescaped JSON.stringify in Script Tags
+**Vulnerability:** XSS vulnerability via unescaped HTML characters (<, >, &) in JSON.stringify output injected into a <script> tag using dangerouslySetInnerHTML.
+**Learning:** The assumption that JSON.stringify escapes forward slashes and HTML characters by default is false. This can lead to script injection if the JSON contains strings like `</script><script>...`.
+**Prevention:** Always manually escape HTML control characters with their unicode equivalents (e.g., `\u003c`) when injecting JSON into HTML script tags.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -15,10 +15,13 @@ interface SchemaScriptProps {
 }
 
 export function SchemaScript({ data }: SchemaScriptProps) {
-  // JSON.stringify produces safe output for script tags — it escapes
-  // forward slashes and special characters. No HTML injection possible
-  // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // JSON.stringify does NOT automatically escape HTML characters.
+  // We must manually escape <, >, and & to prevent XSS vulnerabilities
+  // when injecting JSON into a <script> tag via dangerouslySetInnerHTML.
+  const jsonLd = JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
 
   return (
     <script


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Cross-Site Scripting (XSS) vulnerability via unescaped HTML characters (`<`, `>`, `&`) in `JSON.stringify` output injected into a `<script>` tag using `dangerouslySetInnerHTML`.
🎯 Impact: This could allow script injection if the JSON contains strings like `</script><script>...`.
🔧 Fix: Manually escaped HTML control characters with their unicode equivalents (e.g., `\u003c`) when injecting JSON into HTML script tags. Added a `.jules/sentinel.md` journal entry to document the learning.
✅ Verification: Ran `pnpm test` and `pnpm build` to verify the application builds successfully. The tests passed, and the changes are strictly localized to the escaping mechanism without affecting the JSON structure.

---
*PR created automatically by Jules for task [5675478024028509692](https://jules.google.com/task/5675478024028509692) started by @hadsern*