### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XSS vulnerability in JSON-LD script tags

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-15 - XSS Vulnerability in SchemaScript JSON-LD Serialization
+**Vulnerability:** XSS via `JSON.stringify` injected into a `<script>` tag via `dangerouslySetInnerHTML`.
+**Learning:** `JSON.stringify` does not automatically escape HTML control characters like `<`, `>`, or `&`. While the comment in the code incorrectly claimed "it escapes forward slashes and special characters," this is false in JavaScript. If user input ever makes its way into the schema data, an attacker could include `</script><script>alert(1)</script>`, which `JSON.stringify` would output verbatim. The browser parser would treat `</script>` as the closing tag for the JSON-LD script, executing the subsequent malicious script.
+**Prevention:** Always manually escape `<` and `>` when injecting `JSON.stringify` output into `<script>` tags, e.g., using `.replace(/</g, '\\u003c')`.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -15,10 +15,12 @@ interface SchemaScriptProps {
 }
 
 export function SchemaScript({ data }: SchemaScriptProps) {
-  // JSON.stringify produces safe output for script tags — it escapes
-  // forward slashes and special characters. No HTML injection possible
-  // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // JSON.stringify does NOT automatically escape HTML control characters.
+  // We must manually escape `<` and `>` to prevent XSS vulnerabilities
+  // (e.g. an attacker injecting `</script><script>alert(1)</script>`).
+  const jsonLd = JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e');
 
   return (
     <script


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `JSON.stringify` does not automatically escape HTML control characters (`<`, `>`, `&`). The `SchemaScript` component takes this output and injects it into a `<script>` tag via `dangerouslySetInnerHTML`. If any schema strings contain `</script><script>alert(1)</script>`, the JSON stringification would maintain the `<` and `>` characters, allowing an attacker to break out of the JSON-LD script block and execute malicious JavaScript on the client.
🎯 Impact: This allows arbitrary JavaScript execution (XSS) on clients loading pages where schema is generated.
🔧 Fix: Manually string replace `<` and `>` with their JSON unicode escape equivalents (`\\u003c` and `\\u003e`).
✅ Verification: `pnpm test`, `pnpm lint`, and `pnpm build` have successfully run. The generated `schema` JSON output is correctly formatted and escaped.

---
*PR created automatically by Jules for task [13016380486855987287](https://jules.google.com/task/13016380486855987287) started by @hadsern*