### PR TITLE
⚡ Bolt: Optimize KnowledgeGraph search and node filtering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-01-20 - KnowledgeGraph Search Optimization
+**Learning:** In large React component arrays like `KnowledgeGraph.tsx`, filtering and searching arrays using `toLowerCase()` causes redundant string allocations and high CPU cycles during user typing events.
+**Action:** Pre-index the data inside the `useMemo` block into a `Map` for O(1) exact lookups and an array of objects with pre-lowercased strings for faster O(N) partial text matching.

--- a/src/components/KnowledgeGraph.tsx
+++ b/src/components/KnowledgeGraph.tsx
@@ -98,16 +98,22 @@ export function KnowledgeGraph({ data, lang }: KnowledgeGraphProps) {
       const t = typeof l.target === 'string' ? l.target : l.target.id;
       return allowed.has(s) && allowed.has(t);
     });
-    return { nodes, links };
+    const nodeMap = new Map<string, GraphNode>();
+    const searchableNodes = nodes.map(n => {
+      nodeMap.set(n.id.toLowerCase(), n);
+      return { n, idLower: n.id.toLowerCase(), titleLower: (n.title || '').toLowerCase() };
+    });
+    return { nodes, links, nodeMap, searchableNodes };
   }, [data.nodes, data.links, enabledTypes]);
 
   const suggestions = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (q.length < 2) return [];
-    return filtered.nodes
-      .filter((n) => n.id.toLowerCase().includes(q) || (n.title || '').toLowerCase().includes(q))
-      .slice(0, 8);
-  }, [filtered.nodes, query]);
+    return filtered.searchableNodes
+      .filter((sn) => sn.idLower.includes(q) || sn.titleLower.includes(q))
+      .slice(0, 8)
+      .map(sn => sn.n);
+  }, [filtered.searchableNodes, query]);
 
   useEffect(() => {
     focusIdRef.current = focusId;
@@ -307,7 +313,7 @@ export function KnowledgeGraph({ data, lang }: KnowledgeGraphProps) {
     }
 
     const focusLower = focus.toLowerCase();
-    const focusNode = filtered.nodes.find((n) => n.id.toLowerCase() === focusLower) || null;
+    const focusNode = filtered.nodeMap.get(focusLower) || null;
     if (!focusNode) return;
     const neighbors = sel.adjacency[focusNode.id] || new Set<string>();
 
@@ -356,8 +362,8 @@ export function KnowledgeGraph({ data, lang }: KnowledgeGraphProps) {
               const q = query.trim().toLowerCase();
               if (!q) return;
               const match =
-                filtered.nodes.find((n) => n.id.toLowerCase() === q) ||
-                filtered.nodes.find((n) => n.id.toLowerCase().includes(q) || (n.title || '').toLowerCase().includes(q)) ||
+                filtered.nodeMap.get(q) ||
+                filtered.searchableNodes.find((sn) => sn.idLower.includes(q) || sn.titleLower.includes(q))?.n ||
                 null;
               if (match) setFocusId(match.id);
             }}


### PR DESCRIPTION
💡 What: Pre-indexed `nodes` into a Map (`nodeMap`) and a pre-lowercased string array (`searchableNodes`) within the `filtered` `useMemo` block in `KnowledgeGraph.tsx`. This avoids repeatedly iterating the entire node list and allocating massive amounts of new `toLowerCase()` strings on every single keydown stroke.
🎯 Why: Filtering nodes array and continuously executing `toLowerCase()` strings inside array iterations causes heavy CPU pressure and UI typing lag when the user queries large node datasets within the component.
📊 Impact: Changing the text search loop to use pre-lowercased strings, and the specific exact-match node focus lookups to a `Map` provides an O(1) performance and drastically removes O(N) array-scanning overheads and repetitive garbage collection from the main thread during typing events.
🔬 Measurement: Verify optimization by interacting with the Filter/Find inputs in the `KnowledgeGraph` component and confirming no functional changes to search behavior but with eliminated `toLowerCase` string processing overheads.

---
*PR created automatically by Jules for task [4897619608573371061](https://jules.google.com/task/4897619608573371061) started by @hadsern*