### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in SchemaScript

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-18 - Prevent XSS in Script Tag Injection
+**Vulnerability:** XSS vulnerability when injecting `JSON.stringify` data into script tags via `dangerouslySetInnerHTML`.
+**Learning:** `JSON.stringify` does not automatically sanitize HTML control characters (`<`, `>`, `&`). If user input reaches this serialization, it could be interpreted as executable HTML/JavaScript.
+**Prevention:** Manually escape `<`, `>`, and `&` to their unicode equivalents (using literal double backslashes, e.g., `\\u003c`) when serializing JSON for injection into `<script>` tags.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -3,7 +3,7 @@
  *
  * Safety: All data comes from typed schema generators in src/lib/schema.ts.
  * No user input is ever passed to this component. The JSON.stringify output
- * is always valid JSON with no HTML special characters unescaped.
+ * must be manually escaped for HTML special characters.
  *
  * Usage:
  *   <SchemaScript data={schemaSiteGraph()} />
@@ -15,10 +15,12 @@ interface SchemaScriptProps {
 }
 
 export function SchemaScript({ data }: SchemaScriptProps) {
-  // JSON.stringify produces safe output for script tags — it escapes
-  // forward slashes and special characters. No HTML injection possible
-  // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // JSON.stringify does NOT automatically sanitize HTML control characters like <, >, and &.
+  // We must manually escape them to prevent XSS vulnerabilities when injecting into a script tag.
+  const jsonLd = JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
 
   return (
     <script


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: XSS vulnerability in `SchemaScript` when injecting `JSON.stringify` data into script tags via `dangerouslySetInnerHTML`. `JSON.stringify` does not escape HTML control characters like `<`, `>`, and `&`, meaning injected user data could potentially be interpreted as executable HTML/JavaScript.
🎯 Impact: An attacker could potentially inject malicious scripts, leading to Cross-Site Scripting (XSS) attacks.
🔧 Fix: Manually escaped `<`, `>`, and `&` to their unicode equivalents (using literal double backslashes, e.g., `\u003c`) when serializing JSON for injection into `<script>` tags in `src/components/SchemaScript.tsx`. Added a learning entry to `.jules/sentinel.md`.
✅ Verification: Ran `pnpm test`, `pnpm build`, and verified the changes do not break existing functionality.

---
*PR created automatically by Jules for task [13420702072694039658](https://jules.google.com/task/13420702072694039658) started by @hadsern*