### PR TITLE
🎨 Palette: Add accessibility attributes to text share popover

### DIFF
--- a/src/components/TextSharePopover.tsx
+++ b/src/components/TextSharePopover.tsx
@@ -88,6 +88,8 @@ export function TextSharePopover() {
         onClick={copyText}
         onMouseDown={(e) => e.preventDefault()}
         title={copied ? 'Copied!' : 'Copy text'}
+        aria-label={copied ? 'Copied!' : 'Copy text'}
+        className="focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded"
       >
         {copied ? (
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -106,6 +108,8 @@ export function TextSharePopover() {
         onClick={shareTwitter}
         onMouseDown={(e) => e.preventDefault()}
         title="Share on X"
+        aria-label="Share on X"
+        className="focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded"
       >
         <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor">
           <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
@@ -117,6 +121,8 @@ export function TextSharePopover() {
         onClick={shareLink}
         onMouseDown={(e) => e.preventDefault()}
         title="Copy page link"
+        aria-label="Copy page link"
+        className="focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded"
       >
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
           <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />


### PR DESCRIPTION
💡 What: Added `aria-label` and `focus-visible` ring styles to the icon-only buttons in the `TextSharePopover`.
🎯 Why: Ensure these interactive elements provide clear context to screen readers and show explicit visual focus indicators during keyboard navigation, improving overall accessibility.
♿ Accessibility:
- Added `aria-label` attributes dynamically matching titles.
- Applied `focus-visible:ring-2` to support keyboard-only users.

---
*PR created automatically by Jules for task [1945100216206112087](https://jules.google.com/task/1945100216206112087) started by @hadsern*