### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XSS vulnerability in schema script

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-17 - Prevent XSS in Script Tag Injection
+**Vulnerability:** Unescaped JSON output injected via `dangerouslySetInnerHTML` into `<script>` tags, making it vulnerable to XSS if `</script>` exists in the payload.
+**Learning:** `JSON.stringify` does not escape HTML control characters (`<`, `>`, `&`). The previous code erroneously assumed it was safe.
+**Prevention:** Always manually escape `<`, `>`, and `&` using literal double backslashes (e.g., `\\u003c`) when using `JSON.stringify` inside `<script>` tags via `dangerouslySetInnerHTML`.

--- a/src/components/SchemaScript.tsx
+++ b/src/components/SchemaScript.tsx
@@ -15,10 +15,14 @@ interface SchemaScriptProps {
 }
 
 export function SchemaScript({ data }: SchemaScriptProps) {
-  // JSON.stringify produces safe output for script tags — it escapes
-  // forward slashes and special characters. No HTML injection possible
-  // from valid JSON serialization of our own typed schema objects.
-  const jsonLd = JSON.stringify(data);
+  // JSON.stringify does NOT automatically escape HTML characters (<, >, &).
+  // When injecting into a <script> tag via dangerouslySetInnerHTML, we must
+  // manually escape these characters to prevent potential XSS vulnerabilities,
+  // even if the data originates from internal typed schema objects.
+  const jsonLd = JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
 
   return (
     <script


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Cross-Site Scripting (XSS) via unescaped JSON data injected via `dangerouslySetInnerHTML` in `<script>` tags.
🎯 **Impact:** If an attacker can inject malicious strings containing `</script><script>alert(1)</script>` into schema data (like titles or abstracts), they could break out of the script context and execute arbitrary JS on the user's browser.
🔧 **Fix:** Replaced unescaped `JSON.stringify` with an explicitly escaped payload containing unicode equivalents `\u003c`, `\u003e`, and `\u0026`. This ensures standard valid JSON outputs that prevent tags from being correctly parsed as HTML by the browser while still executing correctly as JSON data.
✅ **Verification:** Verified by checking that `pnpm test`, `pnpm lint`, and `pnpm build` still run without issues, preserving original schema structures and safely handling XSS payloads.

---
*PR created automatically by Jules for task [11973464486373373198](https://jules.google.com/task/11973464486373373198) started by @hadsern*