### PR TITLE
🎨 Palette: Add accessible labels to text share popover buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Build script artifacts
+**Learning:** Running `pnpm build` generates public assets like `search-index-*.json` and `catalog.json` which get tracked by git.
+**Action:** When performing local builds to verify changes, ensure that build artifacts are reset using `git checkout HEAD -- <files>` before submitting to avoid polluting the PR with large lockfiles or generated JSON assets.

--- a/src/components/TextSharePopover.tsx
+++ b/src/components/TextSharePopover.tsx
@@ -88,13 +88,14 @@ export function TextSharePopover() {
         onClick={copyText}
         onMouseDown={(e) => e.preventDefault()}
         title={copied ? 'Copied!' : 'Copy text'}
+        aria-label={copied ? 'Copied!' : 'Copy text'}
       >
         {copied ? (
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
             <path d="M20 6L9 17l-5-5" />
           </svg>
         ) : (
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
             <rect x="9" y="9" width="13" height="13" rx="2" />
             <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
           </svg>
@@ -106,8 +107,9 @@ export function TextSharePopover() {
         onClick={shareTwitter}
         onMouseDown={(e) => e.preventDefault()}
         title="Share on X"
+        aria-label="Share on X"
       >
-        <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor">
+        <svg aria-hidden="true" width="13" height="13" viewBox="0 0 24 24" fill="currentColor">
           <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
         </svg>
       </button>
@@ -117,8 +119,9 @@ export function TextSharePopover() {
         onClick={shareLink}
         onMouseDown={(e) => e.preventDefault()}
         title="Copy page link"
+        aria-label="Copy page link"
       >
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
           <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
           <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
         </svg>


### PR DESCRIPTION
💡 What: Added `aria-label` to the copy, X (Twitter), and link share buttons in the `TextSharePopover` component. Also explicitly hid the decorative SVGs from screen readers using `aria-hidden="true"`.
🎯 Why: Icon-only buttons lacking accessible names are problematic for screen reader users. This ensures the purpose of the share buttons is clearly communicated to assistive technologies.
📸 Before/After: No visual change.
♿ Accessibility: Improved screen reader support for the share popover component by providing explicit textual names for icon-only interactive elements and hiding redundant visual SVG data.

---
*PR created automatically by Jules for task [10054301077593028154](https://jules.google.com/task/10054301077593028154) started by @hadsern*