### PR TITLE
⚡ Bolt: pre-index search terms in KnowledgeGraph

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - Search Indexing in KnowledgeGraph
+**Learning:** To optimize search and filtering performance in React components processing large arrays (like KnowledgeGraph.tsx), pre-index data within useMemo into a Map for O(1) exact lookups and an array of objects with pre-lowercased strings for case-insensitive partial matches, significantly reducing CPU cycles spent on redundant string conversions and traversals during user events.
+**Action:** Pre-index large arrays in useMemo with maps and pre-lowercased attributes when repetitive search/filter events exist to avoid costly O(n) re-conversions.

--- a/src/components/KnowledgeGraph.tsx
+++ b/src/components/KnowledgeGraph.tsx
@@ -101,13 +101,28 @@ export function KnowledgeGraph({ data, lang }: KnowledgeGraphProps) {
     return { nodes, links };
   }, [data.nodes, data.links, enabledTypes]);
 
+  const searchIndex = useMemo(() => {
+    const map = new Map<string, GraphNode>();
+    const list = filtered.nodes.map((node) => {
+      const idLower = node.id.toLowerCase();
+      map.set(idLower, node);
+      return {
+        node,
+        idLower,
+        titleLower: (node.title || '').toLowerCase(),
+      };
+    });
+    return { map, list };
+  }, [filtered.nodes]);
+
   const suggestions = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (q.length < 2) return [];
-    return filtered.nodes
-      .filter((n) => n.id.toLowerCase().includes(q) || (n.title || '').toLowerCase().includes(q))
+    return searchIndex.list
+      .filter((n) => n.idLower.includes(q) || n.titleLower.includes(q))
+      .map((n) => n.node)
       .slice(0, 8);
-  }, [filtered.nodes, query]);
+  }, [searchIndex, query]);
 
   useEffect(() => {
     focusIdRef.current = focusId;
@@ -307,7 +322,7 @@ export function KnowledgeGraph({ data, lang }: KnowledgeGraphProps) {
     }
 
     const focusLower = focus.toLowerCase();
-    const focusNode = filtered.nodes.find((n) => n.id.toLowerCase() === focusLower) || null;
+    const focusNode = searchIndex.map.get(focusLower) || null;
     if (!focusNode) return;
     const neighbors = sel.adjacency[focusNode.id] || new Set<string>();
 
@@ -318,7 +333,7 @@ export function KnowledgeGraph({ data, lang }: KnowledgeGraphProps) {
       return s === focusNode.id || t === focusNode.id ? 0.9 : 0.08;
     });
     sel.label.style('opacity', (d: GraphNode) => (d.id === focusNode.id || neighbors.has(d.id) ? 1 : 0));
-  }, [focusId, filtered.nodes]);
+  }, [focusId, searchIndex]);
 
   return (
     <div ref={containerRef} className="w-full h-[600px] relative bg-frc-void border border-frc-blue/30 rounded-lg overflow-hidden">
@@ -356,8 +371,8 @@ export function KnowledgeGraph({ data, lang }: KnowledgeGraphProps) {
               const q = query.trim().toLowerCase();
               if (!q) return;
               const match =
-                filtered.nodes.find((n) => n.id.toLowerCase() === q) ||
-                filtered.nodes.find((n) => n.id.toLowerCase().includes(q) || (n.title || '').toLowerCase().includes(q)) ||
+                searchIndex.map.get(q) ||
+                searchIndex.list.find((n) => n.idLower.includes(q) || n.titleLower.includes(q))?.node ||
                 null;
               if (match) setFocusId(match.id);
             }}


### PR DESCRIPTION
💡 What: Pre-indexed search data within a `useMemo` hook in the KnowledgeGraph component.

🎯 Why: To avoid redundant $O(N)$ string `.toLowerCase()` operations and conversions on every keystroke when users search the KnowledgeGraph.

📊 Impact: Reduces CPU cycles during filtering by providing pre-computed lowercase IDs/titles and enabling $O(1)$ node lookup via a `Map`, yielding smoother interactions for large data sets.

🔬 Measurement: Review memory usage and flame charts in DevTools when typing quickly into the graph search. Memory GC pauses and event loop blocking times should decrease compared to re-instantiating lowercase objects on every render iteration.

---
*PR created automatically by Jules for task [6588641769948131378](https://jules.google.com/task/6588641769948131378) started by @hadsern*