### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-14 - Regex Optimization for Large Files
+**Learning:** Using full-file capturing regular expressions like `([\s\S]*)$` causes massive memory pressure in Node.js/V8 when parsing large markdown files.
+**Action:** Use a fast-fail check like `content.startsWith('---')` to bypass regex execution when possible, and use a non-greedy regex to match only the target block combined with `String.prototype.slice()` to efficiently extract the remaining body.

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -115,16 +115,21 @@ export interface HomeConfig {
 
 /** Parse YAML-like frontmatter from markdown string */
 export function parseFrontmatter(content: string): ParsedContent {
+  if (!content.startsWith('---')) {
+    return { frontmatter: { title: '', id: '' }, body: content, raw: content };
+  }
+
   // Allow whitespace + trailing comments on delimiter lines.
-  // Some content mistakenly uses `---# Title` on the closing delimiter line; treat it as `---` + comment.
-  const fmRegex = /^---[^\S\r\n]*(?:#.*)?\r?\n([\s\S]*?)\r?\n---[^\S\r\n]*(?:#.*)?\r?\n?([\s\S]*)$/;
+  // Match only the frontmatter section.
+  const fmRegex = /^---[^\S\r\n]*(?:#.*)?\r?\n([\s\S]*?)\r?\n---[^\S\r\n]*(?:#.*)?\r?\n?/;
   const match = content.match(fmRegex);
 
   if (!match) {
     return { frontmatter: { title: '', id: '' }, body: content, raw: content };
   }
 
-  const [, fmRaw, body] = match;
+  const fmRaw = match[1];
+  const body = content.slice(match[0].length);
   const frontmatter = parseYamlFrontmatter(fmRaw);
 
   return { frontmatter: frontmatter as unknown as RawFrontmatter, body: body.trim(), raw: content };


### PR DESCRIPTION
💡 What: Modified `parseFrontmatter` to avoid processing the entire file string within a regular expression.
🎯 Why: A greedy `([\s\S]*)$` regex causes V8/Node to load massive file strings into the regex engine and consume substantial time and memory.
📊 Impact: Considerably faster parsing times and lower memory pressure when `src/lib/content.ts` is invoked for large or many files during build/search indexing.
🔬 Measurement: Verify changes with `pnpm test`, `pnpm lint`, and `pnpm build`, which all succeed correctly while using this optimized path.

---
*PR created automatically by Jules for task [2187626139644883020](https://jules.google.com/task/2187626139644883020) started by @hadsern*