### PR TITLE
🎨 Palette: [UX improvement] Enhance accessibility of TextSharePopover buttons

### DIFF
--- a/src/components/TextSharePopover.tsx
+++ b/src/components/TextSharePopover.tsx
@@ -88,13 +88,15 @@ export function TextSharePopover() {
         onClick={copyText}
         onMouseDown={(e) => e.preventDefault()}
         title={copied ? 'Copied!' : 'Copy text'}
+        aria-label={copied ? 'Copied!' : 'Copy text'}
+        className="focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded"
       >
         {copied ? (
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
             <path d="M20 6L9 17l-5-5" />
           </svg>
         ) : (
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
             <rect x="9" y="9" width="13" height="13" rx="2" />
             <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
           </svg>
@@ -106,8 +108,10 @@ export function TextSharePopover() {
         onClick={shareTwitter}
         onMouseDown={(e) => e.preventDefault()}
         title="Share on X"
+        aria-label="Share on X"
+        className="focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded"
       >
-        <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
         </svg>
       </button>
@@ -117,8 +121,10 @@ export function TextSharePopover() {
         onClick={shareLink}
         onMouseDown={(e) => e.preventDefault()}
         title="Copy page link"
+        aria-label="Copy page link"
+        className="focus-visible:ring-2 focus-visible:ring-frc-gold focus-visible:outline-none rounded"
       >
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
           <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
           <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
         </svg>


### PR DESCRIPTION
### 💡 What:
Enhanced the accessibility and keyboard navigation of the `TextSharePopover` component.

### 🎯 Why:
The three icon-only buttons (Copy text, Share on X, Copy page link) lacked descriptive ARIA labels, making them invisible or confusing to screen reader users. They also lacked clear visual focus states, making them difficult to use for keyboard-only users. Redundant SVG announcements were also an issue.

### 📸 Before/After:
*Before:*
- Screen readers either didn't announce the buttons or tried to read raw SVG content.
- Tabbing to the buttons provided no visual indication of focus.

*After:*
- Screen readers correctly announce "Copy text" (or "Copied!"), "Share on X", and "Copy page link".
- Tabbing to the buttons clearly shows a golden focus ring (`ring-frc-gold`).
- SVGs are hidden from screen readers.

### ♿ Accessibility:
- Added dynamic `aria-label` to the Copy button (matches its `title`).
- Added static `aria-label`s to the X and Link buttons.
- Added `aria-hidden="true"` to all inner `<svg>` elements.
- Added Tailwind `focus-visible` classes to all three buttons to ensure a visible focus ring on keyboard focus, without interfering with mouse click states.

---
*PR created automatically by Jules for task [12889663548340390446](https://jules.google.com/task/12889663548340390446) started by @hadsern*